### PR TITLE
fix:ailwindの自動ビルドが動くように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
@@ -68,3 +67,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "tailwindcss-rails", "~> 3.3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,11 +236,11 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
-    tailwindcss-rails (4.4.0)
+    tailwindcss-rails (3.3.2)
       railties (>= 7.0.0)
-      tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.1.18-aarch64-linux-gnu)
-    tailwindcss-ruby (4.1.18-x86_64-linux-gnu)
+      tailwindcss-ruby (~> 3.0)
+    tailwindcss-ruby (3.4.19-aarch64-linux)
+    tailwindcss-ruby (3.4.19-x86_64-linux)
     thor (1.5.0)
     timeout (0.6.0)
     tsort (0.2.0)
@@ -279,7 +279,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails
+  tailwindcss-rails (~> 3.3.2)
   turbo-rails
   web-console
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
+//= link application.tailwind.css
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,0 @@
-@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>App</title>
+    <title>Pankabi</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
     <%= javascript_importmap_tags %>
   </head>
 

--- a/compose.yml
+++ b/compose.yml
@@ -23,13 +23,15 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: bash -c "bundle install && rails db:prepare && rm -f tmp/pids/server.pid && rails s -b 0.0.0.0"
+   # 修正: bin/dev を使う（これでTailwindの自動ビルドが走る）
+    command: bash -c "bundle install && rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
     tty: true
     stdin_open: true
     volumes:
       - .:/app
       - bundle_data:/usr/local/bundle:cached
-      - node_modules:/app/node_modules
+   # 修正2: ビルドディレクトリを保護する（ホストの空ファイルでの上書き防止）
+      - rails_builds:/app/app/assets/builds
     ports:
       - "3000:3000"
     environment:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"
+# Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.paths << Rails.root.join("app/assets/builds")
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    // require('@tailwindcss/forms'),
+    // require('@tailwindcss/typography'),
+    // require('@tailwindcss/container-queries'),
+  ]
+}


### PR DESCRIPTION
Renderデプロイは上手く行ったものの、
localhost:3000でTailwindcssが反映されない問題が発生

tailwindcssを手動でビルドしましたが、反映されず以下の対応を行ったところ表示されるようになりました。

```
# 1. 一旦、中途半端な生成物を掃除する
docker compose exec web rm -rf public/assets
docker compose exec web rm -rf app/assets/builds/*

# 2. ローカルで強制的に「本番と同じビルド」を一度試す
docker compose exec web rails assets:precompile

# 3. Railsサーバーを再起動
docker compose restart web
```

`compose.yml`
Tailwindの自動ビルドが走る設置になっていなかったので修正しました。
[![Image from Gyazo](https://i.gyazo.com/e8acf2b6ef82964308cf61c5c31c2807.png)](https://gyazo.com/e8acf2b6ef82964308cf61c5c31c2807)

closes #13 