### PR TITLE
Feature/password reset02

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,5 +75,6 @@ gem "rspec-rails", "~> 7.1", :groups => [:development, :test]
 gem "devise"
 
 group :development do
-  gem 'letter_opener'
+  gem 'letter_opener'      # メールをすぐブラウザで確認したい場合
+  gem 'letter_opener_web'  # 過去メールを一覧で見たい場合
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,11 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.7.0)
     loofah (2.25.0)
       crass (~> 1.0.2)
@@ -314,6 +319,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   letter_opener
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.4)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -10,3 +10,8 @@ ja:
       inactive: "アカウントが有効化されていません"
       invalid: "メールアドレスまたはパスワードが違います"
       not_found_in_database: "メールアドレスまたはパスワードが違います"
+    passwords:
+      send_instructions: "パスワード再設定のメールを送信しました"
+      updated: "パスワードが変更されました"
+      user:
+        send_instructions:"パスワード再設定用のメールを送信しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,14 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+   require "letter_opener_web"
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   devise_for :users, controllers: { sessions: 'users/sessions' }
   root "top#index"
   get "/home", to: "home#index"
   resources :breads, only: [:index]
 
-  # ゲストログイン
   post 'users/guest_sign_in', to: 'users/sessions#guest'
-
-  # ヘルスチェックエンドポイント
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## 概要
- パスワード再設定機能の実装
- LetterOpenerWeb 導入・開発環境メール確認対応

## 変更内容
- Devise パスワード再設定画面を追加
- 開発環境で letter_opener_web を導入してメール確認可能に
- routes.rb に LetterOpenerWeb をマウント（開発環境のみ）
- フラッシュメッセージを日本語化 
 
## 動作確認方法
1. 開発環境でユーザー登録済みメールアドレスを入力してパスワード再設定リクエスト
2. letter_opener_web でメールを確認
3. メール内のリンク（トークン付きURL）をクリック
4. パスワード再設定画面が開くことを確認
5. 新しいパスワードでログインできることを確認 

## 補足
- 本番環境でのメール送信設定はまだ未実装
- メールテキストは未編集 

close #38 
