### PR TITLE
消費期限の表示を追加

### DIFF
--- a/app/views/home/_bread_card.html.erb
+++ b/app/views/home/_bread_card.html.erb
@@ -9,6 +9,15 @@
     <p class="text-lg font-bold mt-2">
       <%= bread.status_message %>
     </p>
+    <span class="bg-yellow-100 px-4 py-4 rounded-2xl inline-block">
+      <p class="text-lg font-semibold">
+        消費期限
+      </p>
+    
+      <p class="text-2xl font-bold">
+        <%= bread.expiration_date&.strftime("%Y年%m月%d日") %>
+      </p>
+    </span>
 
   </div>
 </div>


### PR DESCRIPTION
## やったこと

パンの消費期限をカード内に表示する機能を追加しました。

## 変更点
- 消費期限を表示
- 表示フォーマットを YYYY年MM月DD日 に統一
- 日付を強調表示（大きめフォント）

## 影響範囲

パンの情報のカードの表示部分

## 動作確認方法
- 登録したパン消費期限が表示されているか確認


## 関連issue
close #41 
