### PR TITLE
パンの「のこり数（在庫）」表示機能追加

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -21,7 +21,9 @@ class Bread < ApplicationRecord
     consumed = daily_consumption * days_passed
     remaining = total_count - consumed
   
+     remaining = remaining.to_i
     remaining.positive? ? remaining : 0
+
   end
 
   # 状態

--- a/app/views/home/_bread_card.html.erb
+++ b/app/views/home/_bread_card.html.erb
@@ -9,13 +9,23 @@
     <p class="text-lg font-bold mt-2">
       <%= bread.status_message %>
     </p>
-    <span class="bg-yellow-100 px-4 py-4 rounded-2xl inline-block">
+    <span class="bg-yellow-100 p-4 mt-4 rounded-2xl inline-block w-56">
       <p class="text-lg font-semibold">
         消費期限
       </p>
     
       <p class="text-2xl font-bold">
         <%= bread.expiration_date&.strftime("%Y年%m月%d日") %>
+      </p>
+    </span>
+
+    <span class="bg-yellow-100 p-4 rounded-2xl inline-block w-56">
+      <p class="text-lg font-semibold">
+        のこり数
+      </p>
+    
+      <p class="text-3xl font-bold">
+        <%= bread.remaining_count %>
       </p>
     </span>
 


### PR DESCRIPTION
## やったこと

パンの入り数と消費ペースを元に「のこり数（在庫）」表示機能をカードに追加しました。

## 変更点
- remaining_count メソッドを使用して残り枚数を表示
- 小数表示（例：3.0）にならないよう整数表示に修正
- 消費期限カードとデザインを統一

## 影響範囲
登録したパンの情報表示部分

## 動作確認方法
- のこり数が整数で表示されていることを確認
 

## 補足
現状ではパンの登録日を購入日としています。

## 関連issue
close #42 
