### PR TITLE
fix:ゲストログイン後の遷移画面の修正

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -17,6 +17,6 @@ class GuestSessionsController < Devise::SessionsController
     end
 
     sign_in(user)
-    redirect_to root_path, notice: "ゲストログインしました"
+    redirect_to home_path, notice: "パン管理をはじめましょう！"
   end
 end


### PR DESCRIPTION
## やったこと
ログアウト後にゲストログインを行うと、
トップ画面に留まる不具合を修正しました。

あわせて、ゲストログイン時のフラッシュメッセージを
UXに合わせた表現へ変更しました。

## 不具合内容
1 ログアウト後にゲストログインを押す
2 「ログインしました」と表示される
3 しかしトップ画面のまま遷移しない
4 2回目の押下でホームに遷移する
#### 原因
ゲストログイン成功後のリダイレクト先がroot_path になっていたため、
ログイン状態と画面遷移の設計が一致していなかった。

## 変更内容
① リダイレクト修正
```
redirect_to root_path
```
↓
```
redirect_to home_path
```
② フラッシュメッセージ改善
```
ゲストログインしました
```
↓
```
パン管理をはじめましょう！
```
※内部用語（ゲストユーザー）を避け、
ユーザー体験にフォーカスした表現へ変更しました。

## 影響範囲

認証周り（ゲストログイン処理）

## 動作確認方法
- 通常ログイン → ログアウト → ゲストログイン → 正常にホームへ遷移
-  ゲストログイン1回目で正常遷移すること確認
  
## 補足
会員登録なしの導線に対して「ゲストログインしました」は
ユーザーにとって必要な情報ではないと判断しました。

本アプリの目的はパン管理の体験であるため、
認証状態の説明ではなく、体験開始を促す表現へ変更しました。

## 関連issue
なし