### PR TITLE
fix: カルーセルのアニメーション制御をtransitionend方式へ変更し挙動を安定化

### DIFF
--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -8,9 +8,10 @@ export default class extends Controller {
     this.total = this.trackTarget.children.length
     this.isAnimating = false
 
-    this.trackTarget.addEventListener("transitionend", () => {
-      this.isAnimating = false
-    })
+  this.trackTarget.addEventListener("transitionend", (event) => {
+    if (event.target !== this.trackTarget) return
+    this.isAnimating = false
+  })
 
     this.createDots()
     this.update()
@@ -29,7 +30,6 @@ export default class extends Controller {
     this.isAnimating = true
 
     this.index = (this.index + direction + this.total) % this.total
-    console.log("index:", this.index)
     this.update()
   }
 


### PR DESCRIPTION
## やったこと

カルーセルで矢印を押しても反応しないことがある問題を修正しました。

アニメーション制御を setTimeout 方式から transitionend 方式へ変更し、
あわせてイベントのバブリング対策を追加することで挙動を安定化させました。

## 変更点
- アニメーション制御を setTimeout 方式から transitionend 方式へ変更
- バブリング対策を追加
  - event.target を確認し、track 自身の transition のみを処理対象とするようにしました。

## 影響範囲
ホーム画面のカルーセル機能

## 動作確認方法
- 矢印連打時の挙動確認

## 補足
今回の修正により一定の安定化は図れましたが、
体感的なスムーズさの向上には限界があると感じています。

本リリース時には、UX向上の観点から
Swiper等のライブラリへの切り替えも検討予定です。

## 関連issue
なし
