### PR TITLE
fix: Docker起動時にdb:migrateを実行するよう修正（本番ゲストログインエラー対応）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ WORKDIR /rails
 
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["sh", "-c", "./bin/rails db:migrate && ./bin/rails server"]


### PR DESCRIPTION
## やったこと
本番環境でゲストログイン時に 500 エラーが発生していた問題を修正しました。

原因は、本番DBに guest カラムが存在しなかったこと（migration未実行）でした。

Docker起動時に db:migrate を実行するよう変更し、
本番環境でも最新のスキーマが適用されるようにしました。

## 変更点
Dockerfile の CMD を変更
- `CMD ["./bin/rails", "server"]`
- `CMD ["sh", "-c", "./bin/rails db:migrate && ./bin/rails server"]`

## 影響範囲
Docker起動フロー
本番／develop環境のDBスキーマ適用

## 動作確認方法
- Render develop 環境でデプロイ
- 起動ログで migration 実行を確認
- ゲストログインが正常に完了することを確認予定

## 補足
将来的には、Docker起動時ではなく
「release phase」的な運用への移行も検討する。

## 関連issue
なし
