### PR TITLE
SendGridを利用したメール送信に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,16 +95,15 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.raise_delivery_errors = true
-
+  
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    port: 465,
-    domain: "gmail.com",
-    user_name: ENV["GMAIL_USERNAME"],
-    password: ENV["GMAIL_PASSWORD"],
-    authentication: "plain",
-    ssl: true,
+    address: "smtp.sendgrid.net",
+    port: 587,
+    domain: "bread-mold-notifier.onrender.com",
+    user_name: "apikey",
+    password: ENV["SENDGRID_API_KEY"],
+    authentication: :plain,
+    enable_starttls_auto: true
   }
   
   config.action_mailer.default_url_options = {


### PR DESCRIPTION
## やったこと

本番環境でGmail SMTPを利用したメール送信がNet::OpenTimeoutで失敗していたため、
SendGridを利用したメール送信に変更しました。

## 変更点
- ActionMailerのSMTP設定をSendGridに変更
- Render環境変数にSENDGRID_API_KEYを追加

## 動作確認方法
- 本番環境で「パスワードを忘れました」を実行
- SendGrid経由でメールが送信されることを確認
