### PR TITLE
Resend APIを利用したパスワードリセットメール送信を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem "devise"
 
 gem "rails-i18n"
 
+gem "resend"
+
 group :development do
   gem 'letter_opener'      # メールをすぐブラウザで確認したい場合
   gem 'letter_opener_web'  # 過去メールを一覧で見たい場合

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -126,6 +127,10 @@ GEM
       railties (>= 6.1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -167,6 +172,8 @@ GEM
     minitest (6.0.1)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
     net-imap (0.6.2)
       date
@@ -246,6 +253,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.0.1)
+      httparty (>= 0.21.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -333,6 +342,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.4)
   rails-i18n
+  resend
   rspec-rails (~> 7.1)
   selenium-webdriver
   sprockets-rails

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,12 @@
+class DeviseMailer < Devise::Mailer
+  def reset_password_instructions(record, token, opts = {})
+    reset_url = edit_password_url(record, reset_password_token: token)
+
+    Resend::Emails.send({
+      from: "Pankabi <noreply@pankabi.app>",
+      to: [record.email],
+      subject: "【Pankabi】パスワード再設定",
+      html: "<p>パスワード再設定はこちら</p><a href='#{reset_url}'>#{reset_url}</a>"
+    })
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,20 +94,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.action_mailer.perform_deliveries = true
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.raise_delivery_errors = true
-  
-  config.action_mailer.smtp_settings = {
-    address: "smtp.sendgrid.net",
-    port: 587,
-    domain: "bread-mold-notifier.onrender.com",
-    user_name: "apikey",
-    password: ENV["SENDGRID_API_KEY"],
-    authentication: :plain,
-    enable_starttls_auto: true
-  }
-  
   config.action_mailer.default_url_options = {
     host: "bread-mold-notifier.onrender.com",
     protocol: "https"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -313,4 +313,6 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+  # config/initializers/devise.rb
+  config.mailer = "DeviseMailer"
 end

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,3 @@
+Resend.configure do |config|
+  config.api_key = ENV["RESEND_API_KEY"]
+end


### PR DESCRIPTION
## やったこと
SMTP接続でタイムアウトが発生していたため、
Resend APIを利用したメール送信に変更しました。
## 変更点
- resend gemを追加
- Resend API設定を追加
- DeviseMailerを作成しパスワードリセットメールを送信

## 影響範囲
本番環境パスワードリセット

## 動作確認方法
- パスワード再設定画面からメール送信
- メールが届くことを確認
