### PR TITLE
chore/ゲストログイン時は一度ログアウトしてからログイン

### DIFF
--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,8 +1,12 @@
 class GuestSessionsController < Devise::SessionsController
   def create
-    # ブラウザから送られた guest_user_id を取得
+    # 既にログインしている場合はログアウト
+    sign_out_all_scopes if user_signed_in?
+  
+    user = nil
     guest_user_id = cookies.signed[:guest_user_id]
-
+    
+    # ブラウザから送られた guest_user_id を取得
     if guest_user_id.present?
       user = User.find_by(id: guest_user_id, guest: true)
     end


### PR DESCRIPTION
## やったこと
一度会員登録した状態でトップ画面でゲストログインすると
通常のログインになってしまう

## 変更点
- guest_ssesion_controller.rbに
　`sign_out_all_scopes if user_signed_in?`を追加

## 影響範囲
ログイン機能

## 動作確認方法
- 会員登録後トップ画面に戻り「今すぐ使う（会員登録なし）」を押すとゲストログインになるか

