### PR TITLE
feature:設定一覧画面にログアウトボタンを追加

### DIFF
--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -23,3 +23,13 @@
   <% end %>
 
 </div>
+
+<% if user_signed_in? %>
+  <div class="text-center text-sm opacity-60 mt-10 max-w-lg mx-auto px-4">
+    <%= button_to "ログアウト",
+      destroy_user_session_path,
+      method: :delete,
+      data: { turbo: false },
+      class: "btn btn-ghost btn-xs" %>
+  </div>
+<% end %>


### PR DESCRIPTION
## やったこと
設定一覧画面からログアウトできるようにするため、ログアウトボタンを追加しました。
ゲストログイン後に通常ログインへ切り替える際の導線を明確にし、トップ画面へ正しい遷移ができるようにしました。

## 変更点
- Deviseの destroy_user_session_path を使用してログアウト処理を実装
- settings/index.html.erb
```
  <% if user_signed_in? %>
  <div class="text-center text-sm opacity-60 mt-10 max-w-lg mx-auto px-4">
    <%= button_to "ログアウト",
      destroy_user_session_path,
      method: :delete,
      data: { turbo: false },
      class: "btn btn-ghost btn-xs" %>
  </div>
<% end %>
```
## 動作確認方法
- ログイン状態で設定一覧画面へ遷移
- 画面下部にログアウトボタンが表示されることを確認
- ボタン押下でログアウトしトップ画面に戻ることを確認

## 補足
ゲストログイン後にブラウザへ guest_user_id のcookieが残ることで、通常ログインを行った際にゲストユーザーとしてログインされてしまうケースがありました。

ログアウトを経由する導線を用意することで、セッションをリセットし正常に通常ログインできるよう改善しました。

