### PR TITLE
feature:在庫数の修正ボタンの追加

### DIFF
--- a/app/controllers/breads_controller.rb
+++ b/app/controllers/breads_controller.rb
@@ -48,6 +48,18 @@ class BreadsController < ApplicationController
     redirect_to home_path, notice: "完食しました！ 🍞"
   end
 
+  def increase
+    bread = Bread.find(params[:id])
+    bread.increment!(:adjustment_count)
+    redirect_to breads_path
+  end
+
+  def decrease
+    bread = Bread.find(params[:id])
+    bread.decrement!(:adjustment_count)
+    redirect_to breads_path
+  end
+
   private
 
   def set_bread

--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -20,11 +20,19 @@ class Bread < ApplicationRecord
   def remaining_count
     days_passed = (Date.current - created_at.to_date).to_i
     consumed = daily_consumption * days_passed
-    remaining = total_count - consumed
+    remaining = total_count - consumed + adjustment_count
   
      remaining = remaining.to_i
     remaining.positive? ? remaining : 0
 
+  end
+
+  def increase_adjustment!
+    increment!(:adjustment_count)
+  end
+
+  def decrease_adjustment!
+    decrement!(:adjustment_count)
   end
 
   # 状態

--- a/app/views/home/_bread_card.html.erb
+++ b/app/views/home/_bread_card.html.erb
@@ -36,15 +36,25 @@
       </p>
     </span>
 
-    <span class="bg-yellow-100 p-4 rounded-2xl inline-block w-60">
-      <p class="text-lg font-semibold">
-        のこり数
-      </p>
+    <div class="flex items-center gap-3">
+      <span class="bg-yellow-100 p-4 rounded-2xl inline-block w-60 text-center">
+        <p class="text-lg font-semibold">
+          のこり数
+        </p>
+
+        <div class="flex items-center justify-center gap-8 mt-2">
+          <%= button_to "-", decrease_bread_path(bread), method: :patch,
+            class: "text-2xl font-bold text-gray-600 hover:text-red-500" %>
     
-      <p class="text-3xl font-bold">
-        <%= bread.remaining_count %>
-      </p>
-    </span>
+          <p class="text-3xl font-bold w-16 text-center">
+            <%= bread.remaining_count %>
+          </p>
+    
+          <%= button_to "+", increase_bread_path(bread), method: :patch,
+            class: "text-2xl font-bold text-gray-600 hover:text-green-500" %>
+        </div>
+      </span>
+    </div>
 
     <%= button_to "完食", bread_path(bread),
               method: :delete,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,12 @@ Rails.application.routes.draw do
   root "top#index"
   get "/home", to: "home#index"
 
-  resources :breads, only: [:new, :create, :edit, :update, :destroy]
+  resources :breads, only: [:new, :create, :edit, :update, :destroy] do
+    member do
+      patch :increase
+      patch :decrease
+    end
+  end
 
   # ゲストログイン
   devise_scope :user do

--- a/db/migrate/20260315111555_add_adjustment_count_to_breads.rb
+++ b/db/migrate/20260315111555_add_adjustment_count_to_breads.rb
@@ -1,0 +1,5 @@
+class AddAdjustmentCountToBreads < ActiveRecord::Migration[7.1]
+  def change
+    add_column :breads, :adjustment_count, :integer, default: 0, null: false 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_10_075850) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_15_111555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_10_075850) do
     t.date "expiration_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "adjustment_count", default: 0, null: false
     t.index ["bread_type_id"], name: "index_breads_on_bread_type_id"
     t.index ["user_id"], name: "index_breads_on_user_id"
   end


### PR DESCRIPTION
## やったこと
パンの残数を手動で調整できる機能を追加しました。
残数表示の左右に ＋ / − ボタンを設置し、クリックで adjustment_count を更新できるようにしています。

## 変更点
- breads テーブルに adjustment_count カラムを追加
- パン残数補正メソッドを追加
- ルーティング追加
- 残数補正アクション追加
- 残数表示の左右に + / - ボタンを設置

## 影響範囲
パン情報カード
breads テーブル

## 動作確認方法
- パンカードの「のこり数」を確認
- ＋ を押す → 残数が増える
- − を押す → 残数が減る

## 補足
今後の改善事項
- Turboを使用してページリロードなしで残数更新

## 関連issue
close #73 
