### PR TITLE
feature/パンの残り数の修正を非同期化

### DIFF
--- a/app/controllers/breads_controller.rb
+++ b/app/controllers/breads_controller.rb
@@ -1,6 +1,6 @@
 class BreadsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_bread, only: [:edit, :update]
+  before_action :set_bread, only: [:edit, :update, :increase, :decrease]
   before_action :set_bread_types, only: [:new, :edit, :create, :update]
 
   def new
@@ -49,15 +49,21 @@ class BreadsController < ApplicationController
   end
 
   def increase
-    bread = Bread.find(params[:id])
-    bread.increment!(:adjustment_count)
-    redirect_to breads_path
+    @bread = Bread.find(params[:id])
+    @bread.increment!(:adjustment_count)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to home_path }
+    end
   end
 
   def decrease
-    bread = Bread.find(params[:id])
-    bread.decrement!(:adjustment_count)
-    redirect_to breads_path
+    @bread.decrement!(:adjustment_count)
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to home_path }
+    end
   end
 
   private

--- a/app/views/breads/decrease.turbo_stream.erb
+++ b/app/views/breads/decrease.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bread_#{@bread.id}_count" do %>
+  <%= render "home/bread_count", bread: @bread %>
+<% end %>

--- a/app/views/breads/increase.turbo_stream.erb
+++ b/app/views/breads/increase.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bread_#{@bread.id}_count" do %>
+  <%= render "home/bread_count", bread: @bread %>
+<% end %>

--- a/app/views/home/_bread_card.html.erb
+++ b/app/views/home/_bread_card.html.erb
@@ -41,18 +41,7 @@
         <p class="text-lg font-semibold">
           のこり数
         </p>
-
-        <div class="flex items-center justify-center gap-8 mt-2">
-          <%= button_to "-", decrease_bread_path(bread), method: :patch,
-            class: "text-2xl font-bold text-gray-600 hover:text-red-500" %>
-    
-          <p class="text-3xl font-bold w-16 text-center">
-            <%= bread.remaining_count %>
-          </p>
-    
-          <%= button_to "+", increase_bread_path(bread), method: :patch,
-            class: "text-2xl font-bold text-gray-600 hover:text-green-500" %>
-        </div>
+        <%= render "home/bread_count", bread: bread %>
       </span>
     </div>
 

--- a/app/views/home/_bread_count.html.erb
+++ b/app/views/home/_bread_count.html.erb
@@ -1,0 +1,11 @@
+<div id="bread_<%= bread.id %>_count">
+  <div class="flex items-center justify-center gap-8 mt-2">
+    <%= button_to "-", decrease_bread_path(bread), method: :patch,
+      class: "text-2xl font-bold text-gray-600 hover:text-red-500" %>
+    <p class="text-3xl font-bold w-16 text-center">
+      <%= bread.remaining_count %>
+    </p>
+    <%= button_to "+", increase_bread_path(bread), method: :patch,
+      class: "text-2xl font-bold text-gray-600 hover:text-green-500" %>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
パン残数の手動補正機能（+ / - ボタン）をTurbo Stream対応し、
ページリロードなしで残数が更新されるように改善しました。

## なぜ必要か
* ページリロードによるチラつきを防ぐため
* 複数カード表示時の挙動を安定させるため
* アプリらしい操作体験を実現するため

## 変更内容
### 機能改善
* 残数の + / - 操作を非同期化（Turbo Stream）
* 該当カードのみ部分更新されるように変更

### View
* 残数表示部分をパーシャル化

```erb
<%= render "home/bread_count", bread: bread %>
```

* 各カードに一意のIDを付与

```erb
<div id="bread_<%= bread.id %>_count">
```

### Controller
* Turbo Stream対応を追加
```ruby
respond_to do |format|
  format.turbo_stream
  format.html { redirect_to home_path }
end
```

### Turbo Stream
* 部分更新用テンプレートを作成

```erb
<%= turbo_stream.replace "bread_#{@bread.id}_count" do %>
  <%= render "home/bread_count", bread: @bread %>
<% end %>
```

## 確認方法
1. ホーム画面を開く
2. パンカードの「のこり数」を確認
3. +/ - ボタンをクリック
4. ページリロードされずに数値のみ更新されることを確認

## 影響範囲
* パン残数表示UI
* breads controller（increase / decrease）

## 学び・工夫した点
* Turbo Streamを用いた部分更新の実装
* DOMのidとturbo_streamのtarget一致の重要性を理解
* ControllerとViewの責務分離を意識した設計


close #115 
