### PR TITLE
fix:本番環境でOCRが動作しない問題の修正

### DIFF
--- a/app/javascript/ocr.js
+++ b/app/javascript/ocr.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   const input = document.getElementById("imageInput")
   const status = document.getElementById("ocrStatus")
   if (!input) return
@@ -19,8 +19,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const data = await res.json()
 
-      alert(JSON.stringify(data)) // ←ここ！！！！！
-
+      alert(JSON.stringify(data)) 
+      
       if (data.expiration) {
         document.getElementById("expirationField").value = data.expiration
         status.textContent = ""


### PR DESCRIPTION
## やったこと
問題
本番環境で画像選択後に処理が実行されない
読み取り中表示も出ない
OCR自体はバックエンドでは正常に動作している状態

原因
Turboによるページ遷移により、
DOMContentLoaded が発火せずJavaScriptが実行されていなかった

## 変更点
- イベントリスナーを DOMContentLoaded → turbo:load に変更
- Turbo環境でも確実にJSが実行されるよう修正
document.addEventListener("turbo:load", () => {

## 影響範囲
OCR機能のフロント処理（画像アップロード〜自動入力）
