### PR TITLE
feat: グループ機能の基盤を実装（Group/Membership導入）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,11 +12,18 @@ class ApplicationController < ActionController::Base
   end
 
   def current_group
+    return @current_group if defined?(@current_group)
+  
+    @current_group =
+      if session[:group_id]
+        current_user.groups.find_by(id: session[:group_id])
+      end
+  
     @current_group ||= current_user.groups.first
   end
-    helper_method :current_group
-  end
-  
+
+  helper_method :current_group
+
   private
 
   def reject_guest_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,13 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end
+
+  def current_group
+    @current_group ||= current_user.groups.first
+  end
+    helper_method :current_group
+  end
+  
   private
 
   def reject_guest_user

--- a/app/controllers/breads_controller.rb
+++ b/app/controllers/breads_controller.rb
@@ -4,21 +4,21 @@ class BreadsController < ApplicationController
   before_action :set_bread_types, only: [:new, :edit, :create, :update]
 
   def new
-    if current_user.default_bread.present?
-      default = current_user.default_bread
+    if current_group.default_bread.present?
+      default = current_group.default_bread
   
-      @bread = current_user.breads.build(
+      @bread = current_group.breads.build(
         bread_type_id: default.bread_type_id,
         total_count: default.total_count,
         daily_consumption: default.daily_consumption
       )
     else
-      @bread = current_user.breads.build
+      @bread = current_group.breads.build
     end
   end
 
   def create
-    @bread = current_user.breads.build(bread_params)
+    @bread = current_group.breads.build(bread_params)
 
     if @bread.save
       redirect_to home_path, notice: "パンを登録しました 🍞"
@@ -43,13 +43,13 @@ class BreadsController < ApplicationController
   end
 
   def destroy
-    @bread = current_user.breads.find(params[:id])
+    @bread = current_group.breads.find(params[:id])
     @bread.destroy
     redirect_to home_path, notice: "完食しました！ 🍞"
   end
 
   def increase
-    @bread = Bread.find(params[:id])
+    @bread = current_group.breads.find(params[:id])
     @bread.increment!(:adjustment_count)
 
     respond_to do |format|
@@ -69,7 +69,7 @@ class BreadsController < ApplicationController
   private
 
   def set_bread
-    @bread = current_user.breads.find(params[:id])
+    @bread = current_group.breads.find(params[:id])
   end
 
   def set_bread_types

--- a/app/controllers/breads_controller.rb
+++ b/app/controllers/breads_controller.rb
@@ -4,9 +4,9 @@ class BreadsController < ApplicationController
   before_action :set_bread_types, only: [:new, :edit, :create, :update]
 
   def new
-    if current_group.default_bread.present?
-      default = current_group.default_bread
-  
+    if current_user.default_bread.present?
+      default = current_user.default_bread
+
       @bread = current_group.breads.build(
         bread_type_id: default.bread_type_id,
         total_count: default.total_count,
@@ -19,6 +19,7 @@ class BreadsController < ApplicationController
 
   def create
     @bread = current_group.breads.build(bread_params)
+    @bread.user = current_user
 
     if @bread.save
       redirect_to home_path, notice: "パンを登録しました 🍞"

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,9 @@
+class GroupsController < ApplicationController
+  before_action :authenticate_user!
+
+  def switch
+    group = current_user.groups.find(params[:id])
+    session[:group_id] = group.id
+    redirect_to home_path, notice: "グループを切り替えました"
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@ class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @breads = current_user.breads
+    @breads = current_group.breads
   end
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,22 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+window.toggleDropdown = function(button) {
+  const dropdown = button.nextElementSibling;
+  dropdown.classList.toggle('hidden');
+}
+
+document.addEventListener('turbo:load', () => {
+  document.removeEventListener('click', handleClick);
+  document.addEventListener('click', handleClick);
+});
+
+function handleClick(e) {
+  document.querySelectorAll('[data-dropdown]').forEach(drop => {
+    if (!drop.contains(e.target)) {
+      const menu = drop.children[1];
+      if (menu) menu.classList.add('hidden');
+    }
+  });
+}

--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -22,10 +22,6 @@ class Bread < ApplicationRecord
     days_passed = (Date.current - created_at.to_date).to_i
     consumed = daily_consumption * days_passed
     remaining = total_count - consumed + adjustment_count
-  
-     remaining = remaining.to_i
-    remaining.positive? ? remaining : 0
-
   end
 
   def increase_adjustment!

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,8 @@
 class Group < ApplicationRecord
   validates :name, presence: true
-  
+
   has_many :memberships
   has_many :users, through: :memberships
+
+  has_many :breads, dependent: :destroy
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ApplicationRecord
+  validates :name, presence: true
+  
+  has_many :memberships
+  has_many :users, through: :memberships
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,4 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   has_many :breads, dependent: :destroy
   has_one :default_bread, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :groups, through: :memberships
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -14,5 +17,13 @@ class User < ApplicationRecord
       password: SecureRandom.hex(10),
       guest: true
     )
+  end
+
+  # ユーザー作成後に個人用グループを作成する
+  after_create :create_personal_group
+
+  def create_personal_group
+    group = Group.create!(name: "マイパン")
+    memberships.create!(group: group)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   after_create :create_personal_group
 
   def create_personal_group
-    group = Group.create!(name: "マイパン")
+    group = Group.create!(name: "マイストック")
     memberships.create!(group: group)
   end
 end

--- a/app/views/home/_bread_count.html.erb
+++ b/app/views/home/_bread_count.html.erb
@@ -2,9 +2,23 @@
   <div class="flex items-center justify-center gap-8 mt-2">
     <%= button_to "-", decrease_bread_path(bread), method: :patch,
       class: "text-2xl font-bold text-gray-600 hover:text-red-500" %>
-    <p class="text-3xl font-bold w-16 text-center">
-      <%= bread.remaining_count %>
-    </p>
+    <div class="relative w-16 text-center">
+
+      <% remaining = bread.remaining_count %>
+          
+      <!-- 中央の0 -->
+      <span class="text-3xl font-bold">
+        <%= [remaining, 0].max %>
+      </span>
+
+      <!-- マイナス -->
+      <% if remaining < 0 %>
+        <span class="absolute left-1/2 top-1/2 translate-x-3 -translate-y-1/2 text-sm text-red-500">
+          （<%= remaining %>）
+        </span>
+      <% end %>
+          
+    </div>
     <%= button_to "+", increase_bread_path(bread), method: :patch,
       class: "text-2xl font-bold text-gray-600 hover:text-green-500" %>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,46 +1,78 @@
 <header class="relative bg-primary text-primary-content h-14">
-  <div class="h-full px-4 flex items-center gap-2">
-    <!-- トップに戻るボタン -->
-    <%= button_to destroy_user_session_path,
-    method: :delete,
-    data: { turbo: false },
-    class: "btn btn-ghost btn-circle" do %>
-
-    <svg xmlns="http://www.w3.org/2000/svg"
-         fill="none"
-         viewBox="0 0 24 24"
-         stroke-width="1.5"
-         stroke="currentColor"
-         class="size-6">
-      <path stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15"/>
-    </svg>
-    <% end %>
-  </div>
-
-  <!-- 右上アイコン（absolute） -->
-  <div class="absolute inset-y-0 right-4 flex items-center gap-2">
-
-  <!-- 通知ベル：会員のみ表示 -->
-  <% if user_signed_in? && !current_user.guest? %>
-    <%= link_to notifications_path, class: "btn btn-ghost btn-circle relative" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"> <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" /> </svg>
-
-
-      <!-- 🔴 未読バッジ -->
-      <% unread_count = current_user.notifications.where(is_read: false).count %>
-      <% if unread_count > 0 %>
-        <span class="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 min-w-[18px] text-center">
-          <%= unread_count %>
-        </span>
+  <div class="h-full grid grid-cols-3 items-center px-4">
+    <!-- 【左】トップに戻るボタン -->
+    <div>
+      <%= button_to destroy_user_session_path,
+      method: :delete,
+      data: { turbo: false },
+      class: "btn btn-ghost btn-circle" do %>
+  
+      <svg xmlns="http://www.w3.org/2000/svg"
+           fill="none"
+           viewBox="0 0 24 24"
+           stroke-width="1.5"
+           stroke="currentColor"
+           class="size-6">
+        <path stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15"/>
+      </svg>
       <% end %>
-    <% end %>
+    </div>
+
+  <!-- 【中央】グループ切替ボタン -->
+  <% unless current_user.guest? %>
+    <div class="flex justify-center">
+      <div class="relative" data-dropdown>
+        <!-- ボタン -->
+        <button onclick="toggleDropdown(this)"
+                class="px-3 py-2 rounded-lg hover:bg-white/10">
+          <%= current_group.name %> ▼
+        </button>
+                
+        <!-- ドロップダウン -->
+        <div class="hidden absolute mt-2 w-48 bg-white border rounded-lg shadow-lg z-10">
+          <% current_user.groups.each do |group| %>
+            <% if group == current_group %>
+              <div class="px-4 py-2 text-gray-400">
+                <%= group.name %>（選択中）
+              </div>
+            <% else %>
+              <%= button_to group.name,
+                    switch_group_path(group),
+                    method: :patch,
+                    class: "w-full text-left px-4 py-2 hover:bg-gray-100" %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
   <% end %>
 
-  <!-- 設定アイコン -->
-  <%= link_to settings_path, class: "btn btn-ghost btn-circle" do %>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"> <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" /> <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /> </svg>
-  <% end %>
+    <!-- 【右】アイコン -->
+    <div class="flex justify-end items-center gap-2">
+
+      <!-- 通知ベル：会員のみ表示 -->
+      <% if user_signed_in? && !current_user.guest? %>
+        <%= link_to notifications_path, class: "btn btn-ghost btn-circle relative" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"> <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" /> </svg>
+    
+    
+          <!-- 🔴 未読バッジ -->
+          <% unread_count = current_user.notifications.where(is_read: false).count %>
+          <% if unread_count > 0 %>
+            <span class="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 min-w-[18px] text-center">
+              <%= unread_count %>
+            </span>
+          <% end %>
+        <% end %>
+      <% end %>
+    
+      <!-- 設定アイコン -->
+      <%= link_to settings_path, class: "btn btn-ghost btn-circle" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"> <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" /> <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /> </svg>
+      <% end %>
+    </div>
+  </div>
 </header>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,12 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   post "/ocr", to: "ocrs#create"
+
+  # グループ関連
+  resources :groups, only: [] do
+    member do
+      patch :switch
+    end
+  end
+
 end

--- a/db/migrate/20260405032251_create_groups.rb
+++ b/db/migrate/20260405032251_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[7.1]
+  def change
+    create_table :groups do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260405032549_create_memberships.rb
+++ b/db/migrate/20260405032549_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration[7.1]
+  def change
+    create_table :memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260405033116_add_group_to_breads.rb
+++ b/db/migrate/20260405033116_add_group_to_breads.rb
@@ -1,0 +1,5 @@
+class AddGroupToBreads < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :breads, :group, foreign_key: true
+  end
+end

--- a/db/migrate/20260405040900_backfill_group_id_to_breads.rb
+++ b/db/migrate/20260405040900_backfill_group_id_to_breads.rb
@@ -1,0 +1,12 @@
+class BackfillGroupIdToBreads < ActiveRecord::Migration[7.1]
+  def up
+    User.find_each do |user|
+      group = user.groups.first || user.groups.create!(name: "マイパン")
+      user.breads.update_all(group_id: group.id)
+    end
+  end
+
+  def down
+    # 戻さないなら空でOK
+  end
+end

--- a/db/migrate/20260405040900_backfill_group_id_to_breads.rb
+++ b/db/migrate/20260405040900_backfill_group_id_to_breads.rb
@@ -1,7 +1,7 @@
 class BackfillGroupIdToBreads < ActiveRecord::Migration[7.1]
   def up
     User.find_each do |user|
-      group = user.groups.first || user.groups.create!(name: "マイパン")
+      group = user.groups.first || user.groups.create!(name: "マイストック")
       user.breads.update_all(group_id: group.id)
     end
   end

--- a/db/migrate/20260405042618_add_not_null_to_breads_group_id.rb
+++ b/db/migrate/20260405042618_add_not_null_to_breads_group_id.rb
@@ -1,0 +1,5 @@
+class AddNotNullToBreadsGroupId < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :breads, :group_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_05_040900) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_05_042618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_05_040900) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "adjustment_count", default: 0, null: false
-    t.bigint "group_id"
+    t.bigint "group_id", null: false
     t.index ["bread_type_id"], name: "index_breads_on_bread_type_id"
     t.index ["group_id"], name: "index_breads_on_group_id"
     t.index ["user_id"], name: "index_breads_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_19_045106) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_05_040900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_19_045106) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "adjustment_count", default: 0, null: false
+    t.bigint "group_id"
     t.index ["bread_type_id"], name: "index_breads_on_bread_type_id"
+    t.index ["group_id"], name: "index_breads_on_group_id"
     t.index ["user_id"], name: "index_breads_on_user_id"
   end
 
@@ -43,6 +45,21 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_19_045106) do
     t.datetime "updated_at", null: false
     t.index ["bread_type_id"], name: "index_default_breads_on_bread_type_id"
     t.index ["user_id"], name: "index_default_breads_on_user_id", unique: true
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "memberships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_memberships_on_group_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -72,9 +89,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_19_045106) do
   end
 
   add_foreign_key "breads", "bread_types"
+  add_foreign_key "breads", "groups"
   add_foreign_key "breads", "users"
   add_foreign_key "default_breads", "bread_types"
   add_foreign_key "default_breads", "users"
+  add_foreign_key "memberships", "groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "notifications", "breads"
   add_foreign_key "notifications", "users"
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :membership do
+    user { nil }
+    group { nil }
+  end
+end

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GroupsHelper. For example:
+#
+# describe GroupsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GroupsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Membership, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Groups", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# なぜ必要か
* 将来的な家族共有機能に向けて、データ構造をグループ単位に変更するため
* パン情報をユーザーではなくグループに紐づけることで拡張性を確保する

# 必要なこと

* [x] Group / Membership モデルの追加
* [x] Bread を group に紐付ける
* [x] 既存データの移行
* [x] current_group の導入
* [x] UIをグループベースに変更（ヘッダー）

# やること（コードレベル）

* [x] Groupモデル作成

* [x] Membershipモデル作成（userとgroupの中間テーブル）

* [x] Breadに group_id を追加

* [x] 既存データに対して group_id を付与（バックフィル）

* [x] group_id に NOT NULL 制約を追加

* [x] association定義

  * User has_many :groups (through: memberships)
  * Group has_many :users (through: memberships)
  * Group has_many :breads
  * Bread belongs_to :group

* [x] current_group を ApplicationController に追加

* [x] breads の取得を current_user.breads → current_group.breads に変更

* [x] セキュリティ対応（findをgroup経由に変更）

* [x] ヘッダーにグループ切り替えUIを追加

* [x] ドロップダウンUIの実装（JS含む）

* [x] ゲストユーザーには非表示

# 完了条件

* [x] 既存ユーザーのパンデータがグループに紐づいている
* [x] group_id が必須（NULL不可）になっている
* [x] current_group.breads で正常に表示される
* [x] グループ切り替えで表示内容が変わる
* [x] UIが崩れていない（ヘッダー含む）

# このissueで実装しないもの

* 招待機能
* グループ作成UI
* グループ権限管理
* グループ切り替えの永続化（session以外）

---

## 補足

* デフォルトグループ名を「マイストック」に変更
* ゲストユーザーはグループ機能を利用不可


## 関連issue
close #97 
