### PR TITLE
Feature/group invite

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -36,6 +36,19 @@ class GroupsController < ApplicationController
     redirect_to home_path, notice: "グループを切り替えました"
   end
 
+  def destroy
+    group = current_user.groups.find(params[:id])
+    
+    if group.default?
+      redirect_to groups_path, alert: "マイストックは削除できません"
+      return
+    end
+  
+    group.destroy
+  
+    redirect_to groups_path, notice: "削除しました"
+  end
+
   private
 
   def group_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,8 +6,8 @@ class GroupsController < ApplicationController
   end
 
   def show
-    @invitation = Invitation.find_by!(token: params[:token])
-    @group = @invitation.group
+    @group = current_user.groups.find(params[:id])
+    @breads = @group.breads
   end
 
   def new
@@ -15,11 +15,16 @@ class GroupsController < ApplicationController
   end
 
   def create
-    invitation = Invitation.find_by!(token: params[:token])
-    invitation.group.users << current_user
-
-    if invitation.group.save
-      redirect_to invitation.group, notice: "作成しました"
+    @group = Group.new(group_params)
+  
+    if @group.save
+      # 自分をメンバーに追加（超重要🔥）
+      @group.users << current_user
+    
+      # current_groupに設定
+      session[:group_id] = @group.id
+    
+      redirect_to @group, notice: "グループを作成しました！"
     else
       render :new
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,9 +1,40 @@
 class GroupsController < ApplicationController
   before_action :authenticate_user!
+  
+  def index
+    @groups = current_user.groups
+  end
+
+  def show
+    @invitation = Invitation.find_by!(token: params[:token])
+    @group = @invitation.group
+  end
+
+  def new
+    @group = Group.new
+  end
+
+  def create
+    invitation = Invitation.find_by!(token: params[:token])
+    invitation.group.users << current_user
+
+    if invitation.group.save
+      redirect_to invitation.group, notice: "作成しました"
+    else
+      render :new
+    end
+  end
 
   def switch
     group = current_user.groups.find(params[:id])
     session[:group_id] = group.id
     redirect_to home_path, notice: "グループを切り替えました"
   end
+
+  private
+
+  def group_params
+    params.require(:group).permit(:name, :description)
+  end
+
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,9 +1,38 @@
 class InvitationsController < ApplicationController
+  before_action :authenticate_user!
+
+  # 招待リンク作成 
+  def create
+    Rails.logger.info "=== INVITE CREATE CALLED ==="
+    group = current_user.groups.find(params[:group_id])
+
+    invitation = group.invitations.create!(
+      token: SecureRandom.urlsafe_base64,
+      expires_at: 3.days.from_now
+    )
+
+    redirect_to group_path(group, invite_token: invitation.token)
+  end
+
+  # 招待ページ表示
   def show
+    @invitation = Invitation.find_by!(token: params[:token])
+    @group = @invitation.group
+  end
+
+  # 参加処理
+  def join
     invitation = Invitation.find_by!(token: params[:token])
 
-    invitation.group.users << current_user
+    if invitation.expires_at < Time.current
+      redirect_to root_path, alert: "期限切れです"
+      return
+    end
 
-    redirect_to invitation.group, notice: "グループに参加しました"
+    unless invitation.group.users.include?(current_user)
+      invitation.group.users << current_user
+    end
+
+    redirect_to group_path(invitation.group), notice: "グループに参加しました！"
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -32,6 +32,7 @@ class InvitationsController < ApplicationController
     unless invitation.group.users.include?(current_user)
       invitation.group.users << current_user
     end
+    session[:group_id] = invitation.group.id
 
     redirect_to group_path(invitation.group), notice: "グループに参加しました！"
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -34,6 +34,6 @@ class InvitationsController < ApplicationController
     end
     session[:group_id] = invitation.group.id
 
-    redirect_to group_path(invitation.group), notice: "グループに参加しました！"
+    redirect_to home_path, notice: "グループに参加しました！"
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,9 @@
+class InvitationsController < ApplicationController
+  def show
+    invitation = Invitation.find_by!(token: params[:token])
+
+    invitation.group.users << current_user
+
+    redirect_to invitation.group, notice: "グループに参加しました"
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,4 +6,9 @@ class Group < ApplicationRecord
 
   has_many :breads, dependent: :destroy
   has_many :invitations, dependent: :destroy
+
+    def default?
+      self.default
+    end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,4 +5,5 @@ class Group < ApplicationRecord
   has_many :users, through: :memberships
 
   has_many :breads, dependent: :destroy
+  has_many :invitations, dependent: :destroy
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,3 @@
+class Invitation < ApplicationRecord
+  belongs_to :group
+end

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: group, local: true do |f| %>
+
+  <!-- グループ名 -->
+  <div class="form-control mb-4">
+    <%= f.label :name, "グループ名", class: "label" %>
+    <%= f.text_field :name,
+          class: "input input-bordered",
+          placeholder: "例：家族" %>
+  </div>
+
+  <!-- ボタン -->
+  <div class="form-control mt-8">
+    <div class="flex justify-center">
+      <%= f.submit group.persisted? ? "更新する" : "作成する",
+            class: "btn btn-primary w-48" %>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,11 +1,52 @@
-<h1>グループ一覧</h1>
+<div class="bg-base-200 min-h-screen pt-6">
+  <div class="max-w-md mx-auto px-4">
 
-<%= link_to "＋ 作成", new_group_path %>
+    <!-- ヘッダー -->
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-lg font-bold">グループ</h1>
 
-<ul>
-  <% @groups.each do |group| %>
-    <li>
-      <%= link_to group.name, group_path(group) %>
-    </li>
-  <% end %>
-</ul>
+      <%= link_to new_group_path,
+          class: "btn btn-primary btn-sm" do %>
+        ＋ 作成
+      <% end %>
+    </div>
+
+    <!-- 一覧 -->
+    <% if @groups.any? %>
+      <div class="space-y-2">
+        <% @groups.each do |group| %>
+          <%= link_to group_path(group),
+                class: "block" do %>
+
+            <div class="bg-base-100 rounded-lg px-4 py-3 shadow-sm hover:bg-base-300 transition flex justify-between items-center">
+
+              <span class="font-medium">
+                <%= group.name %>
+              </span>
+
+              <span class="text-base-content/40">
+                ›
+              </span>
+
+            </div>
+
+          <% end %>
+        <% end %>
+      </div>
+
+    <% else %>
+      <!-- 空状態 -->
+      <div class="text-center mt-10">
+        <p class="text-sm opacity-60 mb-4">
+          グループがまだありません
+        </p>
+
+        <%= link_to new_group_path,
+              class: "btn btn-primary w-full" do %>
+          ＋ グループを作成
+        <% end %>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,11 @@
+<h1>グループ一覧</h1>
+
+<%= link_to "＋ 作成", new_group_path %>
+
+<ul>
+  <% @groups.each do |group| %>
+    <li>
+      <%= link_to group.name, group_path(group) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,8 @@
+<h1>グループ作成</h1>
+
+<%= form_with model: @group do |f| %>
+  <%= f.text_field :name, placeholder: "グループ名" %>
+  <%= f.text_area :description, placeholder: "説明（任意）" %>
+
+  <%= f.submit "作成" %>
+<% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -4,7 +4,7 @@
 
       <!-- 閉じる -->
       <div class="absolute top-4 right-4">
-        <%= link_to groups_path,
+        <%= link_to home_path,
             class: "w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 text-lg" do %>
           ×
         <% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,8 +1,23 @@
-<h1>グループ作成</h1>
+<div class="bg-base-200 min-h-screen pt-10">
+  <div class="max-w-sm mx-auto ">
+    <div class="card bg-base-100 shadow-xl relative">
 
-<%= form_with model: @group do |f| %>
-  <%= f.text_field :name, placeholder: "グループ名" %>
-  <%= f.text_area :description, placeholder: "説明（任意）" %>
+      <!-- 閉じる -->
+      <div class="absolute top-4 right-4">
+        <%= link_to groups_path,
+            class: "w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 text-lg" do %>
+          ×
+        <% end %>
+      </div>
 
-  <%= f.submit "作成" %>
-<% end %>
+      <div class="card-body">
+        <h2 class="card-title text-xl mb-4">
+          グループを作成 👥
+        </h2>
+
+        <%= render "form", group: @group %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,23 @@
+<h1><%= @group.name %></h1>
+
+<p>メンバー</p>
+<ul>
+  <% @group.users.each do |user| %>
+    <li><%= user.name %></li>
+  <% end %>
+</ul>
+
+<!-- 招待ボタン -->
+<%= button_to "＋ 招待する",
+      group_invitations_path(@group),
+      method: :post %>
+
+<!-- 招待リンク表示 -->
+<% if params[:invite_token] %>
+  <div>
+    <p>招待リンク</p>
+    <input type="text"
+           value="<%= invite_url(params[:invite_token]) %>"
+           readonly>
+  </div>
+<% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,23 +1,54 @@
-<h1><%= @group.name %></h1>
+<div class="bg-base-200 min-h-screen pt-6">
+  <div class="max-w-md mx-auto px-4">
 
-<p>メンバー</p>
-<ul>
-  <% @group.users.each do |user| %>
-    <li><%= user.name %></li>
-  <% end %>
-</ul>
+    <!-- グループ名 -->
+    <div class="card bg-base-100 shadow mb-6">
+      <div class="card-body text-center">
+        <h2 class="text-xl font-bold">
+          <%= @group.name %>
+        </h2>
+      </div>
+    </div>
 
-<!-- 招待ボタン -->
-<%= button_to "＋ 招待する",
-      group_invitations_path(@group),
-      method: :post %>
+    <!-- 招待ボタン -->
+    <div class="flex justify-center mb-4">
+      <%= button_to "＋ 招待リンクを作成",
+            group_invitations_path(@group),
+            method: :post,
+            class: "btn btn-primary w-48" %>
+    </div>
 
-<!-- 招待リンク表示 -->
-<% if params[:invite_token] %>
-  <div>
-    <p>招待リンク</p>
-    <input type="text"
-           value="<%= invite_url(params[:invite_token]) %>"
-           readonly>
+    <!-- 招待リンク表示 -->
+    <% if params[:invite_token] %>
+      <div class="card bg-base-100 shadow">
+        <div class="card-body">
+
+          <p class="text-sm mb-2">招待リンク</p>
+
+          <input type="text"
+                 id="invite-link"
+                 value="<%= invite_url(params[:invite_token]) %>"
+                 readonly
+                 class="input input-bordered w-full text-sm" />
+
+          <div class="flex justify-center mb-4">
+            <button onclick="copyInviteLink()"
+                    class="btn btn-sm mt-3 w-48">
+             コピー
+            </button>
+          </div>
+
+        </div>
+      </div>
+    <% end %>
+
   </div>
-<% end %>
+</div>
+
+<script>
+function copyInviteLink() {
+  const input = document.querySelector("#invite-link");
+  navigator.clipboard.writeText(input.value);
+  alert("コピーしました！");
+}
+</script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,38 +1,39 @@
 <%= render "layouts/header" %>
 
 <div class="min-h-[calc(100vh-4rem)] bg-base-200 flex flex-col">
-  <div data-controller="carousel" class="relative w-full overflow-hidden mt-6">
-  
-    <div data-carousel-target="track"
-         class="flex w-full transition-transform duration-300 ease-in-out">
-  
-      <% @breads.each do |bread| %>
+  <div data-controller="carousel" class="relative w-full mt-6">
+    <div class="overflow-hidden">
+      <div data-carousel-target="track"
+           class="flex w-full transition-transform duration-300 ease-in-out">
+          
+        <% @breads.each do |bread| %>
+          <div class="w-full shrink-0 flex justify-center">
+            <%= render "bread_card", bread: bread %>
+          </div>
+        <% end %>
+        
+        <!-- パン登録カードは最後に固定表示 -->
         <div class="w-full shrink-0 flex justify-center">
-          <%= render "bread_card", bread: bread %>
+          <%= render "no_bread_card" %>
         </div>
-      <% end %>
-  
-      <!-- パン登録カードは最後に固定表示 -->
-      <div class="w-full shrink-0 flex justify-center">
-        <%= render "no_bread_card" %>
+        
       </div>
-  
-    </div>
-  
-    <button data-action="click->carousel#prev"
-            class="absolute left-5 top-1/2 -translate-y-1/2 btn btn-circle">
-      ❮
-    </button>
-  
-    <button data-action="click->carousel#next"
-            class="absolute right-5 top-1/2 -translate-y-1/2 btn btn-circle">
-      ❯
-    </button>
-
-        <!-- ドットエリア追加 -->
-    <div class="flex justify-center mt-4 space-x-2"
-         data-carousel-target="dots">
-    </div>
+        
+      <button data-action="click->carousel#prev"
+              class="absolute left-5 top-1/2 -translate-y-1/2 btn btn-circle">
+        ❮
+      </button>
+              
+      <button data-action="click->carousel#next"
+              class="absolute right-5 top-1/2 -translate-y-1/2 btn btn-circle">
+        ❯
+      </button>
+              
+          <!-- ドットエリア追加 -->
+      <div class="flex justify-center mt-4 space-x-2"
+           data-carousel-target="dots">
+      </div>
+    </div
 
   
 </div>

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,7 +1,26 @@
-<h1>招待されています</h1>
+<div class="bg-base-200 min-h-screen flex items-center justify-center px-4">
+  <div class="card bg-base-100 shadow-xl w-full max-w-sm">
 
-<p><%= @group.name %> に参加しますか？</p>
+    <div class="card-body text-center">
 
-<%= button_to "参加する",
-      invite_path(params[:token]),
-      method: :post %>
+      <h2 class="text-lg font-bold mb-2">
+        グループに招待されています
+      </h2>
+
+      <p class="text-xl font-semibold mb-4">
+        <%= @group.name %>
+      </p>
+
+      <p class="text-sm opacity-60 mb-6">
+        このグループに参加しますか？
+      </p>
+
+      <%= button_to "参加する",
+            join_invite_path(@invitation.token),
+            method: :post,
+            class: "btn btn-primary w-full" %>
+
+    </div>
+
+  </div>
+</div>

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,0 +1,7 @@
+<h1>招待されています</h1>
+
+<p><%= @group.name %> に参加しますか？</p>
+
+<%= button_to "参加する",
+      invite_path(params[:token]),
+      method: :post %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="relative bg-primary text-primary-content h-14">
-  <div class="h-full grid grid-cols-3 items-center px-4">
+<header class="relative z-50 bg-primary text-primary-content h-14">
+  <div class="h-full flex items-center justify-between px-4">
     <!-- 【左】トップに戻るボタン -->
     <div>
       <%= button_to destroy_user_session_path,
@@ -22,8 +22,8 @@
 
   <!-- 【中央】グループ切替ボタン -->
   <% unless current_user.guest? %>
-    <div class="flex justify-center">
-      <div class="relative" data-dropdown>
+    <div class="absolute left-1/2 -translate-x-1/2">
+      <div class="relative z-50" data-dropdown>
         <!-- ボタン -->
         <button onclick="toggleDropdown(this)"
                 class="px-3 py-2 rounded-lg hover:bg-white/10">
@@ -31,7 +31,7 @@
         </button>
                 
         <!-- ドロップダウン -->
-        <div class="hidden absolute mt-2 w-48 bg-white border rounded-lg shadow-lg z-10">
+        <div class="hidden absolute mt-2 w-48 bg-white border rounded-lg shadow-lg z-50">
           <% current_user.groups.each do |group| %>
             <% if group == current_group %>
               <div class="px-4 py-2 text-gray-400">
@@ -57,7 +57,7 @@
   <% end %>
 
     <!-- 【右】アイコン -->
-    <div class="flex justify-end items-center gap-2">
+    <div class="flex items-center gap-2">
 
       <!-- 通知ベル：会員のみ表示 -->
       <% if user_signed_in? && !current_user.guest? %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -44,6 +44,13 @@
                     class: "w-full text-left px-4 py-2 hover:bg-gray-100" %>
             <% end %>
           <% end %>
+
+          <!-- 区切り線 -->
+          <div class="border-t my-1"></div> 
+          <!-- 追加 -->
+          <%= link_to new_group_path, class: "block px-4 py-2 text-primary hover:bg-gray-100" do %>
+            ＋ グループを作成
+          <% end %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   post "/ocr", to: "ocrs#create"
 
   # グループ関連
-  resources :groups, only: [:index, :show, :new, :create] do
+  resources :groups, only: [:index, :show, :new, :create, :destroy] do
     member do
       patch :switch
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,6 @@ Rails.application.routes.draw do
   end
   
   get  "/invite/:token", to: "invitations#show", as: :invite
-  post "/invite/:token", to: "invitations#create"
+  post "/invite/:token/join", to: "invitations#join", as: :join_invite
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,10 +49,15 @@ Rails.application.routes.draw do
   post "/ocr", to: "ocrs#create"
 
   # グループ関連
-  resources :groups, only: [] do
+  resources :groups, only: [:index, :show, :new, :create] do
     member do
       patch :switch
     end
+  
+    resources :invitations, only: [:create]
   end
+  
+  get  "/invite/:token", to: "invitations#show", as: :invite
+  post "/invite/:token", to: "invitations#create"
 
 end

--- a/db/migrate/20260406131507_create_invitations.rb
+++ b/db/migrate/20260406131507_create_invitations.rb
@@ -1,0 +1,11 @@
+class CreateInvitations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :invitations do |t|
+      t.references :group, null: false, foreign_key: true
+      t.string :token
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260407122729_add_default_to_groups.rb
+++ b/db/migrate/20260407122729_add_default_to_groups.rb
@@ -1,0 +1,5 @@
+class AddDefaultToGroups < ActiveRecord::Migration[7.1]
+  def change
+    add_column :groups, :default, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_06_131507) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_07_122729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_06_131507) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "default"
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_05_042618) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_06_131507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_05_042618) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "invitations", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.string "token"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_invitations_on_group_id"
+  end
+
   create_table "memberships", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
@@ -93,6 +102,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_05_042618) do
   add_foreign_key "breads", "users"
   add_foreign_key "default_breads", "bread_types"
   add_foreign_key "default_breads", "users"
+  add_foreign_key "invitations", "groups"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"
   add_foreign_key "notifications", "breads"

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :invitation do
+    group { nil }
+    token { "MyString" }
+    expires_at { "2026-04-06 22:15:07" }
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Invitation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 概要

グループ作成および招待機能を実装しました。

* グループ作成機能
* 招待リンク発行機能
* 招待リンクからの参加機能
* current_groupによるグループ状態管理
* ホーム画面でのグループ切り替え対応


# 変更内容

## グループ機能

* GroupsControllerの作成（index / show / create）
* ユーザーとグループの関連付け
* グループ一覧画面の実装

## 招待機能

* InvitationsControllerの作成
* トークン付き招待リンクの発行
* 招待ページ（/invite/:token）の実装
* 参加処理（join）の実装

## グループ参加処理

* 招待リンクからグループ参加可能に
* 既存ユーザーの重複参加防止
* 有効期限チェックの追加

## 状態管理

* session[:group_id] による current_group 管理
* ApplicationControllerに current_group を実装
* helper_methodでviewから参照可能に

## 画面遷移

* 参加後は /home にリダイレクト
* HomeControllerで current_group.breads を表示

## UI改善

* 招待リンクコピー機能の実装（clipboard API）
* グループ切り替えドロップダウンの実装

---

# 変更理由

* グループ単位でデータを管理するため
* ユーザー同士でグループ共有を可能にするため
* アプリの利用体験を向上させるため（状態ベースUI）

# 確認方法
1. グループを作成する
2. 招待リンクを発行する
3. 別ユーザーで招待リンクにアクセスする
4. 「参加する」を押す
5. ホーム画面に遷移し、対象グループのデータが表示されることを確認
6. グループ切り替えが正常に動作することを確認

# 影響範囲
* グループ関連機能全体
* ホーム画面の表示ロジック（current_group依存）

# 今後の対応
* グループ設定画面の実装
* グループ削除機能（設定画面から）
* メンバー管理機能
* 招待リンク管理機能

# 補足
* マイストック（デフォルトグループ）は削除不可とする予定
* URLは /home に統一し、状態で表示を切り替える設計にしています


## 関連issue
close #106 
