### PR TITLE
グループ削除機能 & 招待UI改善

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -44,8 +44,16 @@ class GroupsController < ApplicationController
       return
     end
   
-    @group.destroy
+    if @group.destroy
+      # セッションが削除したグループを指している場合はクリアする
+      if session[:group_id].to_i == @group.id
+        session.delete(:group_id)
+      end
+
       redirect_to groups_path, notice: "グループを削除しました"
+    else
+      redirect_to group_path(@group), alert: "グループの削除に失敗しました"
+    end
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -37,16 +37,15 @@ class GroupsController < ApplicationController
   end
 
   def destroy
-    group = current_user.groups.find(params[:id])
+    @group = current_user.groups.find(params[:id])
     
-    if group.default?
-      redirect_to groups_path, alert: "マイストックは削除できません"
+    if @group.default?
+      redirect_to group_path(@group), alert: "このグループは削除できません"
       return
     end
   
-    group.destroy
-  
-    redirect_to groups_path, notice: "削除しました"
+    @group.destroy
+      redirect_to groups_path, notice: "グループを削除しました"
   end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 class Group < ApplicationRecord
   validates :name, presence: true
 
-  has_many :memberships
+  has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
 
   has_many :breads, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,13 @@ class User < ApplicationRecord
   after_create :create_personal_group
 
   def create_personal_group
-    group = Group.create!(name: "マイストック")
-    memberships.create!(group: group)
+    ActiveRecord::Base.transaction do
+      group = Group.create!(
+        name: "マイストック",
+        default: true
+      )
+      memberships.create!(group: group)
+    end
   end
+
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,9 +1,11 @@
+<%= render "shared/sub_header", title: "グループ共有👥",back_path: settings_path %>
+
 <div class="bg-base-200 min-h-screen pt-6">
   <div class="max-w-md mx-auto px-4">
 
     <!-- ヘッダー -->
     <div class="flex justify-between items-center mb-4">
-      <h1 class="text-lg font-bold">グループ</h1>
+      <h1 class="text-lg font-bold">グループ一覧</h1>
 
       <%= link_to new_group_path,
           class: "btn btn-primary btn-sm" do %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -42,7 +42,7 @@
         </p>
 
         <%= link_to new_group_path,
-              class: "btn btn-primary w-full" do %>
+              class: "btn btn-primary w-48" do %>
           ＋ グループを作成
         <% end %>
       </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,47 +1,83 @@
-<div class="bg-base-200 min-h-screen pt-6">
-  <div class="max-w-md mx-auto px-4">
+<div class="bg-base-200 min-h-screen pt-10">
+  <div class="max-w-sm mx-auto px-4">
+    <div class="card bg-base-100 shadow-xl relative">
 
-    <!-- グループ名 -->
-    <div class="card bg-base-100 shadow mb-6">
-      <div class="card-body text-center">
-        <h2 class="text-xl font-bold">
+      <!-- 閉じる -->
+      <div class="absolute top-4 right-4">
+        <%= link_to groups_path,
+            class: "w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 text-lg" do %>
+          ×
+        <% end %>
+      </div>
+
+      <div class="card-body">
+
+        <!-- タイトル -->
+        <h2 class="card-title text-xl mb-2">
           <%= @group.name %>
         </h2>
-      </div>
-    </div>
 
-    <!-- 招待ボタン -->
-    <div class="flex justify-center mb-4">
-      <%= button_to "＋ 招待リンクを作成",
-            group_invitations_path(@group),
-            method: :post,
-            class: "btn btn-primary w-48" %>
-    </div>
+        <p class="text-sm text-gray-500 mb-4">
+          グループの管理
+        </p>
 
-    <!-- 招待リンク表示 -->
-    <% if params[:invite_token] %>
-      <div class="card bg-base-100 shadow">
-        <div class="card-body">
+        <!-- 招待ボタン -->
+        <%= button_to "＋ 招待リンクを作成",
+              group_invitations_path(@group),
+              method: :post,
+              class: "btn btn-primary w-full mb-4" %>
 
-          <p class="text-sm mb-2">招待リンク</p>
+        <!-- 招待リンク -->
+        <% if params[:invite_token] %>
+          <div class="bg-base-200 p-3 rounded-lg mb-4">
+            <p class="text-xs mb-2 text-gray-500">招待リンク</p>
 
-          <input type="text"
-                 id="invite-link"
-                 value="<%= invite_url(params[:invite_token]) %>"
-                 readonly
-                 class="input input-bordered w-full text-sm" />
+            <input type="text"
+                  id="invite-link"
+                  value="<%= invite_url(params[:invite_token]) %>"
+                  readonly
+                  class="input input-bordered w-full text-sm" />
 
-          <div class="flex justify-center mb-4">
             <button onclick="copyInviteLink()"
-                    class="btn btn-sm mt-3 w-48">
-             コピー
+                    class="btn btn-sm mt-2 w-full">
+              コピー
             </button>
           </div>
+        <% end %>
 
-        </div>
+        <!-- 区切り -->
+        <div class="divider my-2"></div>
+                            
+        <% if @group.default? %>
+          <!-- 削除できない説明 -->
+          <p class="text-xs text-gray-400 text-right">
+            このグループは削除できません
+          </p>
+        <% else %>
+          <!-- 削除 -->
+          <div class="flex justify-end">
+            <%= button_to group_path(@group),
+                  method: :delete,
+                  data: { confirm: "本当に削除しますか？" },
+                  class: "text-red-500 hover:bg-red-50 p-2 rounded-full" do %>
+                  
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   fill="none"
+                   viewBox="0 0 24 24"
+                   stroke-width="1.5"
+                   stroke="currentColor"
+                   class="w-6 h-6">
+                <path stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.108 0 0 0-7.5 0" />
+              </svg>
+                  
+            <% end %>
+          </div>
+        <% end %>
+
       </div>
-    <% end %>
-
+    </div>
   </div>
 </div>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="relative z-50 bg-primary text-primary-content h-14">
+<header class="relative z-10 bg-primary text-primary-content h-14">
   <div class="h-full flex items-center justify-between px-4">
     <!-- 【左】トップに戻るボタン -->
     <div>
@@ -23,7 +23,7 @@
   <!-- 【中央】グループ切替ボタン -->
   <% unless current_user.guest? %>
     <div class="absolute left-1/2 -translate-x-1/2">
-      <div class="relative z-50" data-dropdown>
+      <div class="relative z-10" data-dropdown>
         <!-- ボタン -->
         <button onclick="toggleDropdown(this)"
                 class="px-3 py-2 rounded-lg hover:bg-white/10">
@@ -31,7 +31,7 @@
         </button>
                 
         <!-- ドロップダウン -->
-        <div class="hidden absolute mt-2 w-48 bg-white border rounded-lg shadow-lg z-50">
+        <div class="hidden absolute mt-2 w-48 bg-white border rounded-lg shadow-lg z-10">
           <% current_user.groups.each do |group| %>
             <% if group == current_group %>
               <div class="px-4 py-2 text-gray-400">

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -12,6 +12,11 @@
     <span class="text-base-content/40">›</span>
   <% end %>
 
+    <%= link_to groups_path, class: "flex items-center justify-between py-4" do %>
+      <span>グループ共有👥</span>
+      <span class="text-base-content/40">›</span>
+    <% end %>
+
   <%= link_to terms_path, class: "flex items-center justify-between py-4" do %>
     <span>利用規約</span>
     <span class="text-base-content/40">›</span>

--- a/db/migrate/20260407221059_fix_default_group_flag.rb
+++ b/db/migrate/20260407221059_fix_default_group_flag.rb
@@ -1,0 +1,10 @@
+class FixDefaultGroupFlag < ActiveRecord::Migration[7.0]
+  def up
+    Group.reset_column_information
+
+    User.find_each do |user|
+      user.groups.update_all(default: false)
+      user.groups.find_by(name: "マイストック")&.update(default: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_07_122729) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_07_221059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## 概要
グループ詳細画面にて、グループ削除機能を追加しました。
あわせて、招待リンクUIの改善と「マイストック」グループの削除制御を実装しています。

## なぜ必要か
* 不要なグループを削除できるようにするため
* グループ管理のUX向上
* マイストック（個人用グループ）を誤って削除できないようにするため

## 実装内容
### ■ グループ削除機能
* グループ詳細画面に削除ボタン（ゴミ箱アイコン）を追加
* `GroupsController#destroy` を実装
* `dependent: :destroy` により memberships も同時削除

### ■ マイストック削除防止
* `default: true` のグループは削除不可
* コントローラで削除をブロック
* UI上でも削除ボタンを非表示
* 代わりに「このグループは削除できません」と表示

### ■ 招待機能UI改善
* 招待リンク生成ボタンをカード内に配置
* 招待リンク表示エリアをデザイン調整
* コピーボタンを設置（clipboard API使用）

[![Image from Gyazo](https://i.gyazo.com/ed650f95ce06721f8a493d54f839fd50.png)](https://gyazo.com/ed650f95ce06721f8a493d54f839fd50)

### ■ UI改善
* カードレイアウトに統一
* ボタン幅を統一（w-full）
* 削除ボタンをアイコン化（右下配置）
* 不要な余白・ズレを調整


## 動作確認
* [ ] グループ削除ができること
* [ ] マイストックが削除できないこと
* [ ] 招待リンクが生成されること
* [ ] コピー機能が動作すること


## このPRでやらないこと
* defaultのDB制約追加
* グループオーナー機能の追加


## 関連issue
close #135 
