### PR TITLE
# グループ機能・招待機能のRSpec追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Rails.application.routes.draw do
   
     resources :invitations, only: [:create]
   end
+
+  resources :invitations, only: [:show], param: :token do
+    post :join, on: :member
+  end
   
   get  "/invite/:token", to: "invitations#show", as: :invite
   post "/invite/:token/join", to: "invitations#join", as: :join_invite

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :group do
-    name { "MyString" }
+    name { "テストグループ" }
+
+    trait :with_user do
+      after(:create) do |group|
+        group.users << create(:user)
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,12 @@ FactoryBot.define do
     sequence(:email) { |n| "test#{n}@example.com" }
     password { "password123" }
     password_confirmation { "password123" }
+
+    trait :with_group do
+      after(:create) do |user|
+        group = create(:group)
+        group.users << user
+      end
+    end
   end
 end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,7 +1,105 @@
 require 'rails_helper'
 
 RSpec.describe "Groups", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before do
+    sign_in user
   end
+
+  describe 'POST /groups' do
+    it 'グループを作成できる' do
+      expect {
+        post groups_path, params: {
+          group: { name: 'テスト'}
+        }
+      }.to change(Group, :count).by(1)
+    end
+
+    it '作成者がメンバーに追加される' do
+      post groups_path, params: {
+        group: { name: 'テスト' }
+      }
+
+      group = Group.last
+      expect(group.users).to include(user)
+    end
+
+    it 'sessionにgroup_idが保存される' do
+      post groups_path, params: {
+        group: { name: 'テスト' }
+      }
+
+      expect(session[:group_id]).to eq(Group.last.id)
+    end
+  end
+
+  describe 'GET /groups/:id' do
+    it '自分のグループは見れる' do
+      group = create(:group)
+      group.users << user
+
+      get group_path(group)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '他人のグループは見れない' do
+      group = create(:group)
+      group.users << other_user
+    
+      get group_path(group)
+    
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /groups/:id/switch' do
+    it 'グループを切り替えられる' do
+      group = create(:group)
+      user.groups << group
+      user.reload
+
+      patch  switch_group_path(group)
+
+      expect(response).to redirect_to(home_path)
+    end
+  end
+
+  describe 'DELETE /groups/:id' do
+    it '通常のグループは削除できる' do
+      group = create(:group)
+      group.users << user
+
+      expect {
+        delete group_path(group)
+      }.to change(Group, :count).by(-1)
+    end
+
+    it 'defaultグループは削除できない' do
+      group = create(:group)
+      group.users << user
+
+      allow_any_instance_of(Group).to receive(:default?).and_return(true)
+
+      delete group_path(group)
+
+      expect(response).to redirect_to(group_path(group))
+    end
+
+    it '削除したグループがsessionにあればクリアされる' do
+      group = create(:group)
+      group.users << user
+
+      # sessionセット
+      post switch_group_path(group)
+
+      delete group_path(group)
+
+      expect(session[:group_id]).to be_nil
+    end
+  end
+
+  
 end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe "Invitations", type: :request do
+  let(:user) { create(:user) }
+  let(:group) { create(:group, :with_user) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'POST /groups/:id/invitations' do
+    it '招待リンクを作成できる' do
+      group = create(:group)
+      group.users << user
+
+      expect {
+        post group_invitations_path(group)
+      }.to change(Invitation, :count).by(1)
+    end
+
+    it 'トークン付きでリダイレクトされる' do
+      group = create(:group)
+      group.users << user
+
+      post group_invitations_path(group)
+
+      invitation = Invitation.last
+      expect(response).to redirect_to(group_path(group, invite_token: invitation.token))
+    end
+  end
+
+  describe 'GET /invitations/:token' do
+    it '招待ページを表示できる' do
+      group = create(:group)
+      invitation = Invitation.create!(
+        group: group,
+        token: SecureRandom.urlsafe_base64,
+        expires_at: 3.days.from_now
+      )
+
+      get invitation_path(invitation.token)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '無効なトークンの場合エラーになる' do
+      expect {
+        get invitation_path("invalidtoken")
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe 'POST /invitations/:token/join' do
+    it 'グループに参加できる' do
+      group = create(:group)
+      invitation = Invitation.create!(
+        group: group,
+        token: SecureRandom.urlsafe_base64,
+        expires_at: 3.days.from_now
+      )
+
+      post join_invite_path(invitation.token)
+
+      expect(group.users).to include(user)
+      expect(session[:group_id]).to eq(group.id)
+      expect(response).to redirect_to(home_path)
+    end
+
+    it '期限切れのトークンは参加できない' do
+      group = create(:group)
+      invitation = Invitation.create!(
+        group: group,
+        token: SecureRandom.urlsafe_base64,
+        expires_at: 1.hour.ago
+      )
+
+      post join_invite_path(invitation.token)
+
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+
+      expect(response.body).to include("期限切れです")
+    end
+
+    it '既に参加している場合は重複しない' do
+      group = create(:group)
+      group.users << user
+      invitation = Invitation.create!(
+        group: group,
+        token: SecureRandom.urlsafe_base64,
+        expires_at: 3.days.from_now
+      )
+
+      post join_invite_path(invitation.token)
+
+      expect(response).to redirect_to(home_path)
+    end
+  end
+end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe "Invitations", type: :request do
     end
 
     it '無効なトークンの場合エラーになる' do
-      expect {
-        get invitation_path("invalidtoken")
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      get invitation_path("invalidtoken")
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -59,7 +58,7 @@ RSpec.describe "Invitations", type: :request do
         expires_at: 3.days.from_now
       )
 
-      post join_invite_path(invitation.token)
+      post join_invitation_path(invitation.token)
 
       expect(group.users).to include(user)
       expect(session[:group_id]).to eq(group.id)
@@ -77,9 +76,7 @@ RSpec.describe "Invitations", type: :request do
       post join_invite_path(invitation.token)
 
       expect(response).to redirect_to(root_path)
-      follow_redirect!
-
-      expect(response.body).to include("期限切れです")
+      expect(flash[:alert]).to eq("期限切れです")
     end
 
     it '既に参加している場合は重複しない' do


### PR DESCRIPTION
## やったこと
グループ機能および招待機能に対するRequest specを追加しました。

## なぜ必要か
* グループ機能の動作保証のため
* 認可（他人のデータにアクセスできないこと）の担保
* 招待リンクの安全性・正確性の担保

## 実装内容
### グループ機能
* [x] グループ作成のテスト
* [x] 作成時にユーザーがメンバーに追加されること
* [x] セッションにgroup_idが保存されること
* [x] 他人のグループにアクセスできないこと（認可）
* [x] グループ切り替え機能
* [x] グループ削除機能

### 招待機能
* [x] 招待リンク作成
* [x] 招待ページ表示
* [x] 無効トークンのハンドリング（404）
* [x] 招待リンクからの参加処理
* [x] 期限切れトークンの制御
* [x] 重複参加防止

## 技術的ポイント
* Request specでHTTPレスポンスベースのテストを実装
* `current_user.groups.find` による認可をテストで担保
* `change`マッチャでDBの状態変化を検証
* redirect時は `flash` を使用してメッセージを確認

## 補足
今後やること
* pendingのテスト整理
* FactoryBotの改善（trait整理）
* system spec追加
* 招待リンクのセキュリティ強化（使い回し防止など）

## 動作確認
* `bundle exec rspec` 実行済み


## 関連issue
close #142 
