### PR TITLE
パンの登録時にもヘッダーが表示されるよう統一

### DIFF
--- a/app/views/breads/new.html.erb
+++ b/app/views/breads/new.html.erb
@@ -1,15 +1,13 @@
-<div class="bg-base-200 min-h-screen pt-10">
+<% content_for :title, "パンを登録 | Pankabi" %>
+<% content_for :description, "パンの在庫や期限を登録できるページです" %>
+<%= render "shared/sub_header", title: "パンを登録🍞", back_path: home_path %>
+
+<div class="bg-base-200 min-h-screen pt-6">
   <div class="max-w-sm mx-auto ">
     <div class="card bg-base-100 shadow-xl relative">
-      <div class="absolute top-4 right-4">
-        <%= link_to home_path,
-            class: "w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 text-lg" do %>
-          ×
-        <% end %>
-      </div>
+
 
       <div class="card-body">
-        <h2 class="card-title text-xl mb-4">パンを登録 🍞</h2>
         <%= render "form", bread: @bread, bread_types: @bread_types %>
       </div>
 


### PR DESCRIPTION
## やったこと
パンの登録時のヘッダーを追加し、他のページと操作感を統一しました。

