### PR TITLE
Feature/carousel ux improvement

### DIFF
--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -23,11 +23,33 @@ export default class extends Controller {
       if (e.key === "ArrowRight") this.next()
     }
     document.addEventListener("keydown", this._handleKeydown)
+
+    // タッチ操作
+    this._touchStartX = 0
+
+    this._handleTouchStart = (e) => {
+      // タッチ開始位置を記録
+      this._touchStartX = e.touches[0].clientX
+  }
+
+  this._handleTouchEnd = (e) => {
+    const diff = this._touchStartX - e.changedTouches[0].clientX
+
+    if (Math.abs(diff) < 50) return // 50px未満の小さい動きは誤操作として無視
+
+    // スワイプ方向に応じて次/前のスライドに移動
+    diff > 0 ? this.next() : this.prev()
+  }
+
+  this.trackTarget.addEventListener("touchstart", this._handleTouchStart, { passive: true })
+  document.addEventListener("touchend", this._handleTouchEnd, { passive: true })
   }
 
   disconnect() {
     clearTimeout(this._animationTimeout)
     document.removeEventListener("keydown", this._handleKeydown)
+    this.trackTarget.removeEventListener("touchstart", this._handleTouchStart)
+    document.removeEventListener("touchend", this._handleTouchEnd)
   }
 
   next() {

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -1,10 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
-console.log("carousel connected")
 export default class extends Controller {
   static targets = ["track", "dots"]
 
   connect() {
-    console.log("carousel connected")
     this.index = 0
     this.total = this.trackTarget.children.length
     this.isAnimating = false
@@ -30,19 +28,19 @@ export default class extends Controller {
     this._handleTouchStart = (e) => {
       // タッチ開始位置を記録
       this._touchStartX = e.touches[0].clientX
-  }
+    }
 
-  this._handleTouchEnd = (e) => {
-    const diff = this._touchStartX - e.changedTouches[0].clientX
+    this._handleTouchEnd = (e) => {
+      const diff = this._touchStartX - e.changedTouches[0].clientX
 
-    if (Math.abs(diff) < 50) return // 50px未満の小さい動きは誤操作として無視
+      if (Math.abs(diff) < 50) return // 50px未満の小さい動きは誤操作として無視
 
-    // スワイプ方向に応じて次/前のスライドに移動
-    diff > 0 ? this.next() : this.prev()
-  }
+      // スワイプ方向に応じて次/前のスライドに移動
+      diff > 0 ? this.next() : this.prev()
+    }
 
-  this.trackTarget.addEventListener("touchstart", this._handleTouchStart, { passive: true })
-  document.addEventListener("touchend", this._handleTouchEnd, { passive: true })
+    this.trackTarget.addEventListener("touchstart", this._handleTouchStart, { passive: true })
+    document.addEventListener("touchend", this._handleTouchEnd, { passive: true })
   }
 
   disconnect() {
@@ -52,13 +50,8 @@ export default class extends Controller {
     document.removeEventListener("touchend", this._handleTouchEnd)
   }
 
-  next() {
-    this.move(1)
-  }
-
-  prev() {
-    this.move(-1)
-  }
+  next() {this.move(1)}
+  prev() {this.move(-1)}
 
   move(direction) {
     if (this.isAnimating) return
@@ -87,9 +80,7 @@ export default class extends Controller {
   }
 
   update() {
-    this.trackTarget.style.transform =
-      `translateX(-${this.index * 100}%)`
-
+    this.trackTarget.style.transform = `translateX(-${this.index * 100}%)`
     this.updateDots()
   }
 

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -9,13 +9,25 @@ export default class extends Controller {
     this.total = this.trackTarget.children.length
     this.isAnimating = false
 
-  this.trackTarget.addEventListener("transitionend", (event) => {
-    if (event.target !== this.trackTarget) return
-    this.isAnimating = false
-  })
+    this.trackTarget.addEventListener("transitionend", (event) => {
+      if (event.target !== this.trackTarget) return
+      this._unlockAnimation()
+    })
 
     this.createDots()
     this.update()
+
+    // キーボード操作
+    this._handleKeydown = (e) => {
+      if (e.key === "ArrowLeft")  this.prev()
+      if (e.key === "ArrowRight") this.next()
+    }
+    document.addEventListener("keydown", this._handleKeydown)
+  }
+
+  disconnect() {
+    clearTimeout(this._animationTimeout)
+    document.removeEventListener("keydown", this._handleKeydown)
   }
 
   next() {
@@ -30,14 +42,24 @@ export default class extends Controller {
     if (this.isAnimating) return
     this.isAnimating = true
 
+    // フォールバック：CSSトランジションの時間 + 余裕を持たせる
+    this._animationTimeout = setTimeout(() => this._unlockAnimation(), 400)
+
     this.index = (this.index + direction + this.total) % this.total
     this.update()
+    }
+
+  _unlockAnimation() {
+    this.isAnimating = false
+    clearTimeout(this._animationTimeout)
   }
 
   goTo(index) {
-    if (this.isAnimating) return
+    // 同じ位置をクリックした場合やアニメーション中は無視
+    if (this.isAnimating || index === this.index) return
 
     this.isAnimating = true
+    this._animationTimeout = setTimeout(() => this._unlockAnimation(), 400)
     this.index = index
     this.update()
   }


### PR DESCRIPTION
# やったこと
カルーセルUIの操作性を改善し、もたつきや誤操作を軽減しました
キーボードの←→でも操作可能にしました
タッチでスワイプできるようにしました

# 変更内容
* connect() でキーイベントを登録し、disconnect() で解除
* キーボード操作とタッチ操作を追加
* タイムアウトをフォールバックとして追加
* ドットの重複生成を防止
* アニメーション中の操作制御を見直し
* インデント修正・コード整理

# 背景・目的

現状のカルーセルは以下の課題がありました

* 操作がもたつく
* 意図しないスワイプが発生する可能性
* UI要素が直感的でない

これらを改善し、より自然な操作感を目指しました

# 影響範囲
* カルーセルUI全体

# 確認方法
* スマホでスワイプ操作が自然に動くこと
* 矢印ボタンで正常に切り替わること
* ドットが正しく表示されること
* アニメーション中に連打しても崩れないこと

