### PR TITLE
feat:フラッシュメッセージを自動で非表示にする動きを追加

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    timeout: { type: Number, default: 2000 }
+  }
+
+  connect() {
+    this.element.style.transform = "translateY(-100%)"
+    this.element.style.transition = "transform 0.35s ease-out"
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.element.style.transform = "translateY(0)"
+      })
+    })
+
+    this.element.addEventListener("mouseenter", () => clearTimeout(this.timeoutId))
+    this.element.addEventListener("mouseleave", () => this.startTimer())
+
+    this.startTimer()
+  }
+
+  startTimer() {
+    this.timeoutId = setTimeout(() => this.dismiss(), this.timeoutValue)
+  }
+
+  dismiss() {
+    this.element.style.transition = "transform 0.4s ease-in"
+    // ヘッダー(56px)分も含めて確実に裏に隠れる量
+    this.element.style.transform = "translateY(calc(-100% - 56px))"
+
+    setTimeout(() => this.element.remove(), 400)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeoutId)
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, "パン在庫一覧 | Pankabi" %>
 <% content_for :description, "登録したパンの在庫や期限を一覧で確認できるページです" %>
-<%= render "layouts/header" %>
+<% content_for :header do %>
+  <%= render "layouts/header" %>
+<% end %>
 
 <div class="min-h-[calc(100vh-4rem)] bg-base-200 flex flex-col">
   <div data-controller="carousel" class="relative w-full mt-6">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="relative z-10 bg-primary text-primary-content h-14">
+<header class="relative z-20 bg-primary text-primary-content h-14">
   <div class="h-full flex items-center justify-between px-4">
     <!-- 【左】トップに戻るボタン -->
     <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,34 +35,34 @@
   </head>
 
 <body class="mx-auto max-w-sm md:max-w-xl min-h-screen relative">
-
-  <% flash.each do |key, message| %>
-    <% bg_class =
-      case key.to_sym
-      when :notice then "bg-info text-primary-content"
-      when :alert  then "bg-error text-error-content"
-      else "bg-base-200 text-base-content"
-      end
-    %>
-  
-    <div class="fixed top-0 left-1/2 -translate-x-1/2 z-50 w-full max-w-sm md:max-w-xl">
-      <div class="alert <%= bg_class %> rounded-none py-2 min-h-14 flex justify-between items-center">
-        <span><%= message %></span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-sm"
-          onclick="this.closest('.alert').parentElement.remove()"
-        >
-          ✕
-        </button>
-      </div>
-    </div>
-  <% end %>
-
   <% if content_for?(:header) %>
     <%= yield :header %>
   <% end %>
 
+  <% if flash.any? %>
+    <div class="relative z-[9]">
+      <div class="absolute top-0 left-0 right-0 pointer-events-none">
+        <% flash.each do |key, message| %>
+          <% bg_class =
+            case key.to_sym
+            when :notice then "bg-info text-primary-content"
+            when :alert  then "bg-error text-error-content"
+            else "bg-base-200 text-base-content"
+            end
+          %>
+          
+          <div 
+            data-controller="flash"
+            class="alert <%= bg_class %> rounded-none py-2 min-h-14 flex items-center
+                 w-full max-w-sm md:max-w-xl pointer-events-auto"
+          >
+            <%= message %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+  
   <main>
     <%= yield %>
   </main>


### PR DESCRIPTION
## やったこと
フラッシュメッセージをヘッダー直下からスライドインし、2秒後に自動でヘッダーの裏に引っ込むアニメーションを実装。

## 変更点
- `flash_controller.js` のアニメーションを `max-height` から `translateY` に変更
- フラッシュのラッパーを `position: absolute` にしてレイアウトから切り離し
- ヘッダーの z-index を `z-10` → `z-20` に変更し、フラッシュ（`z-[9]`）がヘッダーの裏に潜れるよう調整
- 各ビューのヘッダー呼び出しを `render "layouts/header"` から `content_for :header` に統一し、描画順を「ヘッダー → フラッシュ → メイン」に修正

## 影響範囲
- フラッシュメッセージが表示されるすべての画面
- ヘッダーを使用するすべてのビュー（`content_for :header` への変更が必要）
- メインコンテンツのレイアウトへの影響なし

## 動作確認方法

- ログイン・ログアウト・グループ切替などフラッシュが発生する操作を行い、ヘッダー直下からスライドインすることを確認
- 2秒後に自動でヘッダーの裏にスライドアウトして消えることを確認
- フラッシュにホバー中はタイマーが止まり、離したら再開することを確認
- フラッシュ表示・非表示でメインコンテンツが動かないことを確認

## やらないこと

- スワイプで閉じる操作（モバイル対応）
- 複数フラッシュが重なった場合のスタック表示

## 補足

`translateY` を採用した理由は、`max-height` や `opacity` と違いレイアウトに影響を与えず、GPU処理されるためアニメーションが滑らかになるため。

退場時に `calc(-100% - 56px)` としているのは、自身の高さ分 + ヘッダー高さ（56px）だけ上に移動することで、ヘッダーの裏に完全に潜り込ませるため。

`requestAnimationFrame` を二重にかけているのは、1フレームだけでは初期状態（`translateY(-100%)`）をブラウザが描画する前にスキップしてアニメーションが発火しないケースがあるため。

## 関連issue
close #150 
