### PR TITLE
Feature/line link

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,16 +2,37 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def line
     auth = request.env["omniauth.auth"]
 
-    @user = User.find_or_create_by!(provider: auth.provider, uid: auth.uid) do |u|
-      u.name ||= auth.info.name
-      u.email = auth.info.email || "#{auth.uid}@example.com"
-      u.password = Devise.friendly_token[0, 20]
+    if auth.blank?
+      redirect_to root_path, alert: "LINEログインに失敗しました"
+      return
     end
 
-    if @user.persisted?
-      sign_in_and_redirect @user, notice: "LINEでログインしました！"
+    if user_signed_in?
+      # 連携
+      current_user.update!(line_user_id: auth.uid)
+
+      redirect_to notification_settings_path, notice: "LINE連携しました！"
+      return
+
     else
-      redirect_to root_path, alert: "ログインに失敗しました"
+      # LINEログイン
+      @user = User.find_or_create_by!(provider: auth.provider, uid: auth.uid) do |u|
+        u.name ||= auth.info.name
+        u.email = auth.info.email || "#{auth.uid}@example.com"
+        u.password = Devise.friendly_token[0, 20]
+      end
+
+      @user.update!(line_user_id: auth.uid)
+
+      if @user.persisted?
+        sign_in_and_redirect @user, notice: "LINEでログインしました！"
+      else
+        redirect_to root_path, alert: "LINEログインに失敗しました"
+      end
     end
+
+  rescue StandardError => e
+    Rails.logger.error("LINEログインエラー: #{e.message}")
+    redirect_to root_path, alert: "LINEログインに失敗しました"
   end
 end

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">NotificationSettings#edit</h1>
-  <p>Find me in app/views/notification_settings/edit.html.erb</p>
-</div>

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -13,7 +13,7 @@
           LINEでお知らせを受け取ることができます。
         </p>
 
-        <% if current_user.line_user_id.present? %>
+        <% if current_user&.line_user_id.present? %>
           <!-- 👇 連携済み -->
           
           <p class="text-green-600 mb-4">

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -1,14 +1,49 @@
 <%= render "shared/sub_header", title: "通知設定", back_path: home_path %>
+
 <div class="min-h-screen bg-base-200 pt-8">
-  <div class="mt-6 mb-4 max-w-lg mx-auto divide-y divide-base-300 px-4">
+  <div class="mt-6 mb-4 max-w-lg mx-auto px-4">
     <div class="card bg-base-100 shadow-md">
       <div class="card-body text-center">
         <h1 class="text-xl font-bold mb-4">
-          通知設定
+          LINE通知設定
         </h1>
-        <p class="text-gray-500">
-          こちらの機能は現在準備中です。
+
+        <p class="text-gray-600 mb-4">
+          パンの食べ忘れや在庫切れを防ぐために、
+          LINEでお知らせを受け取ることができます。
         </p>
+
+        <% if current_user.line_user_id.present? %>
+          <!-- 👇 連携済み -->
+          
+          <p class="text-green-600 mb-4">
+            LINE連携済みです
+          </p>
+
+          <%= form_with model: current_user, url: user_path(current_user), method: :patch do |f| %>
+            <label class="flex items-center justify-center gap-2 mb-4">
+              <%= f.check_box :line_notify_enabled %>
+              <span>LINE通知を受け取る</span>
+            </label>
+
+            <%= f.submit "保存", class: "btn btn-primary" %>
+          <% end %>
+
+        <% else %>
+          <!-- 👇 未連携 -->
+
+          <p class="text-gray-500 mb-4">
+            LINE通知を利用するには連携が必要です
+          </p>
+
+          <%= button_to "LINEと連携する",
+              user_line_omniauth_authorize_path,
+              method: :post,
+              data: { turbo: false },
+              class: "btn btn-success" %>
+
+        <% end %>
+
       </div>
     </div>
   </div>

--- a/app/views/notification_settings/update.html.erb
+++ b/app/views/notification_settings/update.html.erb
@@ -1,4 +1,0 @@
-<div>
-  <h1 class="font-bold text-4xl">NotificationSettings#update</h1>
-  <p>Find me in app/views/notification_settings/update.html.erb</p>
-</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -321,6 +321,7 @@ Devise.setup do |config|
   # config/initializers/devise.rb
   config.mailer = "DeviseMailer"
 
-  config.omniauth :line, ENV['LINE_CHANNEL_ID'], ENV['LINE_CHANNEL_SECRET']
+  config.omniauth :line, ENV['LINE_CHANNEL_ID'], ENV['LINE_CHANNEL_SECRET'],
+                  scope: 'profile openid email'
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,9 @@ Rails.application.routes.draw do
   get "guest/to_signup", to: "guest#to_signup", as: :guest_to_signup
   get "guest/to_login", to: "guest#to_login", as: :guest_to_login
 
-  resource :notification_setting, only: [:show, :edit, :update]
+  resource :notification_setting, only: [:show]
+  # ユーザー更新（ON/OFF用）
+  resources :users, only: [:update]
 
   resources :notifications, only: [:index]
 

--- a/db/migrate/20260421013039_add_line_to_users.rb
+++ b/db/migrate/20260421013039_add_line_to_users.rb
@@ -1,0 +1,6 @@
+class AddLineToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :line_user_id, :string
+    add_column :users, :line_notify_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_13_011224) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_21_013039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,6 +97,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_13_011224) do
     t.string "provider"
     t.string "uid"
     t.string "name"
+    t.string "line_user_id"
+    t.boolean "line_notify_enabled", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/notification_settings_spec.rb
+++ b/spec/requests/notification_settings_spec.rb
@@ -7,19 +7,4 @@ RSpec.describe "NotificationSettings", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/notification_settings/edit"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /update" do
-    it "returns http success" do
-      get "/notification_settings/update"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
## やったこと
LINE連携機能を実装

既存ユーザーでもLINE通知を利用できるように、LINEログインとは別に「LINE連携」の仕組みを追加

## 実装内容
- usersテーブルに `line_user_id` を追加
- 通知設定画面にLINE連携ボタンを追加
- LINEログインユーザーはline_user_id = uidにしline_user_idを埋める


## 確認方法

1. 通常ログイン（メールなど）でログイン
2. 通知設定画面へ遷移
3. 「LINEと連携する」ボタンをクリック
4. LINE認証画面に遷移することを確認
5. 認証後、通知設定画面にリダイレクトされることを確認
6. Railsコンソールで `line_user_id` が保存されていることを確認

```bash
docker compose exec web rails c
User.last.line_user_id

## 補足
- LINE連携後、LINEによる通知を許可するかどうかはチェックボックスによって管理します。
- userにline_notify_enabledを追加し、デフォルトではfalseとしています。

## 関連issue
close #100 
