### PR TITLE
LINE通知が来ない原因調査・修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,9 +9,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if user_signed_in?
       # 連携
-      current_user.update!(line_user_id: auth.uid)
+      current_user.update!(
+        line_user_id: auth.uid,
+        line_notify_enabled: true
+      )
 
-      redirect_to notification_settings_path, notice: "LINE連携しました！"
+      redirect_to notification_settings_path, notice: "LINE連携しました！通知をONにしました"
       return
 
     else

--- a/app/services/line_client.rb
+++ b/app/services/line_client.rb
@@ -17,7 +17,10 @@ class LineClient
         { type: "text", text: message }
       ]
     }.to_json
+    
+    response = http.request(req)
 
-    http.request(req)
+    Rails.logger.info "LINE response code: #{response.code}"
+    Rails.logger.info "LINE response body: #{response.body}"
   end
 end


### PR DESCRIPTION
## やったこと
LINEによる通知が来ない原因を探るため、ログの表示を追加しました。
LINE連携後、通知を受け取るチェックを自動で入るようにしました。

## 補足
ログを確認後、修正します。
