### PR TITLE
fix:LINE通知の重複を防ぐためカラムを追加

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -74,12 +74,12 @@ class Bread < ApplicationRecord
   end
 
   def create_notification(type, message)
-  return if Notification.exists?(
-    user: user,
-    bread: self,
-    notification_type: type,
-    created_at: Time.zone.today.all_day
-  )
+    # 同じ通知が5分以内に作成されていたらスキップ
+    return if Notification.exists?(
+      bread: self,
+      notification_type: type,
+      created_at: 5.minutes.ago..Time.zone.now
+    )
 
   Notification.create!(
     user: user,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,4 @@
 class Notification < ApplicationRecord
-  after_create :send_line_notification
-
   belongs_to :user
   belongs_to :bread
 

--- a/db/migrate/20260424053124_add_line_sent_to_notifications.rb
+++ b/db/migrate/20260424053124_add_line_sent_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddLineSentToNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :notifications, :line_sent, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_21_013039) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_24_053124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_21_013039) do
     t.datetime "notified_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "line_sent", default: false, null: false
     t.index ["bread_id"], name: "index_notifications_on_bread_id"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -3,10 +3,6 @@ namespace :notification do
   task check: :environment do
     Rails.logger.info "Cron START"
 
-    Bread.find_each do |bread|
-      bread.send(:notify_if_needed)
-    end
-
     Notification.where(line_sent: false).find_each do |notification|
       user = notification.user
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -2,18 +2,20 @@ namespace :notification do
   desc "通知チェック"
   task check: :environment do
     Rails.logger.info "Cron START"
-    Notification.destroy_all  # ← 一時的に追加
 
     Bread.find_each do |bread|
-      user = bread.user
-      Rails.logger.info "bread_id: #{bread.id}"
-
-      Rails.logger.info "line_user_id: #{user.line_user_id}"
-      Rails.logger.info "notify_enabled: #{user.line_notify_enabled}"
-      Rails.logger.info "expiration: #{bread.expiration_date}"
-      Rails.logger.info "remaining: #{bread.remaining_count}"
-      
       bread.send(:notify_if_needed)
+    end
+
+    Notification.where(line_sent: false).find_each do |notification|
+      user = notification.user
+
+      next unless user.line_user_id.present?
+      next unless user.line_notify_enabled?
+
+      LineClient.push_message(user, notification.message)
+
+      notification.update!(line_sent: true)
     end
   end
 end


### PR DESCRIPTION
## やったこと
LINE通知機能の設計を見直し、
「通知生成（アプリ内）」と「LINE送信（Cron）」を分離しました。

### 問題点
Notification.exists? によりLINE通知が送信されないケースが発生
アプリ内通知とLINE通知が同一トリガーで管理されていた
after_createでLINE送信していたため制御が難しい

## 変更点

1.  通知とLINE送信の責務分離
　Notification：アプリ内通知（イベント記録）
　LINE送信：Cronで一括処理

2.line_sent カラム追加 
 ```
add_column :notifications, :line_sent, :boolean, default: false, null: false
```
送信済みかどうかを判定

3.Notificationのコールバック削除
4.Cronの責務を「LINE送信のみに変更」
```
Notification.where(line_sent: false).find_each do |notification|
  user = notification.user

  next unless user.line_user_id.present?
  next unless user.line_notify_enabled?

  LineClient.push_message(user, notification.message)

  notification.update!(line_sent: true)
end
``` 
5.通知重複制御の見直し
変更前
```
# 1日1回制限（LINE送信にも影響）
Notification.exists?(...)
```
変更後
```
# 短時間の重複のみ防止（5分）
Notification.exists?(
  bread: self,
  notification_type: type,
  created_at: 5.minutes.ago..Time.zone.now
)
```

## 動作仕様
パン登録・更新
→ Notification作成（アプリ内通知）

Cron（毎朝）
→ 未送信（line_sent: false）の通知のみLINE送信
→ line_sent: true に更新

## 影響範囲
- アプリ内通知
- LINEによる通知 

## 動作確認方法
- Cron Job実行後LINE通知が来るか
- 同じ通知が重複して来ないか
 
## やらないこと
LINE通知の内容の改善