### PR TITLE
Feature/customize line notification message

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -58,19 +58,36 @@ class Bread < ApplicationRecord
   end
 
   def notify_if_needed
-    # ① 期限今日
     if expiration_date == Time.zone.today
-      create_notification("expiration_today", "パンの消費期限が今日までです！")
+      message = build_message("expiration_today")
+      create_notification("expiration_today", message)
     end
-  
-    # ② 明日在庫切れ
+
     if daily_consumption > 0
       tomorrow_remaining = remaining_count - daily_consumption
-  
+
       if tomorrow_remaining <= 0 && remaining_count > 0
-        create_notification("run_out_tomorrow", "明日パンの在庫がなくなります！")
+        message = build_message("run_out_tomorrow")
+        create_notification("run_out_tomorrow", message)
       end
     end
+  end
+
+  # メッセージ
+  def build_message(type)
+    greeting = greeting_message
+
+    case type
+    when "expiration_today"
+      "#{greeting}\n\n📢 パンの消費期限が今日までです！\nお早めにご確認ください 👀"
+    when "run_out_tomorrow"
+      "#{greeting}\n\n📦 明日パンの在庫がなくなります！\n補充をお忘れなく 🛒"
+    end
+  end
+
+  # あいさつメッセージ
+  def greeting_message
+    "おはようございます ☀️"
   end
 
   def create_notification(type, message)

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,8 +1,18 @@
 namespace :notification do
-  desc "通知チェック"
-  task check: :environment do
-    Rails.logger.info "Cron START"
+  desc "通知作成"
+  task create: :environment do
+    Bread.where(notify_enabled: true)
+         .where("remaining_count > 0")
+         .where("expiration_date >= ?", Date.today)
+         .find_each do |bread|
+      bread.notify_if_needed
+    end
+  end
+end
 
+namespace :notification do
+  desc "通知送信"
+  task send: :environment do
     Notification.where(line_sent: false).find_each do |notification|
       user = notification.user
 


### PR DESCRIPTION
## やったこと
LINE通知機能の改善を行いました。

## 変更内容
- 通知メッセージをカスタマイズ（挨拶文追加・内容改善）
- 通知対象のパンをスコープで絞り込み
  - notify_enabled: true
  - remaining_count > 0
  - expiration_date >= 今日
- 通知作成処理と送信処理を分離
  - notification:create
  - notification:send

## 背景
古いパンデータや不要な通知が処理対象に含まれていたため、
対象データの絞り込みと責務分離を実施しました。

## 確認方法
- Cron実行時に不要なログ（期限切れ・在庫マイナスのパン）が出力されないこと
- LINE通知が正常に送信されること

## 補足
既存の古いNotificationデータは残っているため、
必要に応じてクリーンアップを検討

## 補足
あいさつメッセージ
[![Image from Gyazo](https://i.gyazo.com/dd1d9271f1f7b969f1181074dd9830cd.png)](https://gyazo.com/dd1d9271f1f7b969f1181074dd9830cd)

## 関連issue
close #158 