### PR TITLE
fix:タイムゾーン設定をJSTに変更

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -14,12 +14,12 @@ class Bread < ApplicationRecord
   def days_until_expiration
     return nil unless expiration_date
 
-    (expiration_date - Date.today).to_i
+    (expiration_date - Time.zone.today).to_i
   end
 
   # 残り枚数
   def remaining_count
-    days_passed = (Date.current - created_at.to_date).to_i
+    days_passed = (Time.zone.today - created_at.in_time_zone.to_date).to_i
     consumed = daily_consumption * days_passed
     remaining = total_count - consumed + adjustment_count
   end

--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -61,8 +61,8 @@ class OcrService
     return nil if parsed_dates.empty?
   
     # 念のため未来優先
-    future_dates = parsed_dates.select { |d| d >= Date.today }
-  
+    future_dates = parsed_dates.select { |d| d >= Time.zone.today }
+
     return future_dates.min if future_dates.any?
   
     parsed_dates.min

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module App
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
   end
 end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -4,7 +4,7 @@ namespace :notification do
     Bread.joins(:user)
          .where(users: { line_notify_enabled: true })
          .where("remaining_count > 0")
-         .where("expiration_date >= ?", Date.today)
+         .where("expiration_date >= ?", Time.zone.today)
          .find_each do |bread|
       bread.notify_if_needed
     end

--- a/spec/requests/breads_spec.rb
+++ b/spec/requests/breads_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "パン登録", type: :request do
         bread_type_id: bread_type.id,
         total_count: 6,
         daily_consumption: 2,
-        expiration_date: Date.today + 3
+        expiration_date: Time.zone.today + 3
       }
     }
 


### PR DESCRIPTION
## 概要
タイムゾーンの不一致により、通知タイミングや日付計算にズレが発生していたため修正しました。

## 変更内容
- RailsのタイムゾーンをJSTに設定
  - `config.time_zone = "Tokyo"`
- 日付取得処理を修正
  - `Date.today` → `Time.zone.today` に統一
- 日付計算処理の修正
  - `created_at.to_date` の利用箇所を見直し
- Cron実行時間をUTC基準に調整（JSTに合わせて9時間補正）
  - create: 22:59 UTC（07:59 JST）
  - send: 23:00 UTC（08:00 JST）

## 背景
- CronはUTC基準で実行されるため、JSTとのズレが発生していた
- `Date.today` を使用していたため、サーバー時間に依存したズレが発生していた

## 確認方法
- Cron実行時間がJSTの想定通り（07:59 / 08:00）になっていること
- 通知内容が最新のロジックで送信されること
- 日付表示・残日数計算が正しく表示されること

## 補足
時間処理は今後も `Time.zone` 系で統一して扱う