### PR TITLE
lineメッセージとアプリ内の通知メッセージを分離

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-end
-class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def update
@@ -8,6 +6,24 @@ class UsersController < ApplicationController
       redirect_to settings_path, notice: "通知設定を更新しました"
     else
       redirect_to settings_path, alert: "更新に失敗しました"
+    end
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      # LINE連携していないユーザーに通知を作成
+      if @user.line_user_id.blank?
+        Notification.create!(
+          user: @user,
+          notification_type: "system",
+          message: "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。",
+        )
+
+        redirect_to home_path
+      else
+        render :new
+      end
     end
   end
 

--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -59,38 +59,19 @@ class Bread < ApplicationRecord
 
   def notify_if_needed
     if expiration_date == Time.zone.today
-      message = build_message("expiration_today")
-      create_notification("expiration_today", message)
+      create_notification("expiration_today")
     end
 
     if daily_consumption > 0
       tomorrow_remaining = remaining_count - daily_consumption
 
       if tomorrow_remaining <= 0 && remaining_count > 0
-        message = build_message("run_out_tomorrow")
-        create_notification("run_out_tomorrow", message)
+        create_notification("run_out_tomorrow")
       end
     end
   end
 
-  # メッセージ
-  def build_message(type)
-    greeting = greeting_message
-
-    case type
-    when "expiration_today"
-      "#{greeting}\n\n📢 パンの消費期限が今日までです！\nお早めにご確認ください 👀"
-    when "run_out_tomorrow"
-      "#{greeting}\n\n📦 明日パンの在庫がなくなります！\n補充をお忘れなく 🛒"
-    end
-  end
-
-  # あいさつメッセージ
-  def greeting_message
-    "おはようございます ☀️"
-  end
-
-  def create_notification(type, message)
+  def create_notification(type)
     # 同じ通知が5分以内に作成されていたらスキップ
     return if Notification.exists?(
       bread: self,
@@ -102,7 +83,6 @@ class Bread < ApplicationRecord
     user: user,
     bread: self,
     notification_type: type,
-    message: message,
     notified_at: Time.zone.now
   )
   end

--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -79,11 +79,11 @@ class Bread < ApplicationRecord
       created_at: 5.minutes.ago..Time.zone.now
     )
 
-  Notification.create!(
-    user: user,
-    bread: self,
-    notification_type: type,
-    notified_at: Time.zone.now
-  )
+    Notification.create!(
+      user: user,
+      bread: self,
+      notification_type: type,
+      notified_at: Time.zone.now
+    )
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -6,8 +6,31 @@ class Notification < ApplicationRecord
     # 期限切れ当日通知
     expiration_today: "expiration_today",
     # 明日在庫切れ通知
-    run_out_tomorrow: "run_out_tomorrow"
+    run_out_tomorrow: "run_out_tomorrow",
+    system: "system"
   }
+
+  def display_message
+    case notification_type
+    when "expiration_today"
+      "パンの消費期限が今日までです"
+    when "run_out_tomorrow"
+      "明日在庫がなくなります"
+    when "system"
+      message
+    end
+  end
+
+  def line_message
+    greeting = "おはようございます ☀️"
+
+    case notification_type
+    when "expiration_today"
+      "#{greeting}\n\n📢 #{display_message}\nお早めにご確認ください 👀"
+    when "run_out_tomorrow"
+      "#{greeting}\n\n📦 #{display_message}\n補充をお忘れなく 🛒"
+    end
+  end
 
     private
 
@@ -18,6 +41,6 @@ class Notification < ApplicationRecord
     return unless user.line_user_id.present?
     return unless user.line_notify_enabled?
 
-    LineClient.push_message(user, message)
+    LineClient.push_message(user, line_message)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -7,7 +7,9 @@ class Notification < ApplicationRecord
     expiration_today: "expiration_today",
     # 明日在庫切れ通知
     run_out_tomorrow: "run_out_tomorrow",
-    system: "system"
+    system: "system",
+    # お知らせ用
+    new_feature: "new_feature"
   }
 
   def display_message

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,17 +11,29 @@
         </p>
       <% end %>
 
-        <% @notifications.each do |notification| %>
-          <div style="border-bottom: 1px solid #ccc; padding: 10px;">
-
+      <% @notifications.each do |notification| %>
+        <% if notification.system? %>
+          <!-- システムお知らせ -->
+          <div style="padding: 12px;">
+            <p style="font-weight: bold;">【お知らせ】</p>
+            <p style="white-space: pre-line;">
+              <%= notification.display_message %>
+            </p>
+          </div>
+          <hr>
+        <% else %>
+          <!-- 通常通知 -->
+          <div style="border-bottom: 1px solid #ccc; padding: 10px; text-align: left;">
             <p style="font-weight: <%= notification.is_read ? 'normal' : 'bold' %>;">
-              <%= notification.message %>
+              <%= notification.display_message %>
             </p>
         
-            <small><%= notification.created_at.strftime("%Y-%m-%d %H:%M") %></small>
-          </div>
+            <small>
+              <%= l notification.created_at, format: :short %>
+            </small>
+          </div>    
         <% end %>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -9,7 +9,6 @@ namespace :notification do
       bread.notify_if_needed
     end
   end
-end
 
   desc "通知送信"
   task send: :environment do

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -11,18 +11,23 @@ namespace :notification do
   end
 end
 
-namespace :notification do
   desc "通知送信"
   task send: :environment do
-    Notification.where(line_sent: false).find_each do |notification|
+    Notification.where(line_sent: false)
+                .where("created_at >= ?", Time.zone.today)
+                .find_each do |notification|
+
       user = notification.user
 
       next unless user.line_user_id.present?
       next unless user.line_notify_enabled?
 
-      LineClient.push_message(user, notification.message)
-
-      notification.update!(line_sent: true)
+      begin
+        LineClient.push_message(user, notification.line_message)
+        notification.update!(line_sent: true)
+      rescue => e
+        Rails.logger.error "[LINE送信失敗] #{e.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
LINE通知用メッセージとアプリ内のお知らせ表示メッセージが同一になっていたため、
責務を分離し用途ごとに適切な形式で生成するように改善しました。

## 変更内容
- Notificationモデルに以下を追加
  - `display_message`（アプリ表示用のシンプルメッセージ）
  - `line_message`（LINE通知用のリッチメッセージ）
- DBにはメッセージ本文ではなく `notification_type` をベースに保存する構成に変更
- Breadモデルからメッセージ生成ロジックを削除し、責務を整理
- LINE送信処理を `notification.line_message` を使用するよう修正
- 通知作成（create）と送信（send）の責務を分離
- システムのお知らせも追加できるよう変更

## 背景
従来はLINE通知用のメッセージをそのままDBに保存していたため、
アプリ内のお知らせ一覧でも同じリッチな文章が表示されてしまい、
表示用途に対して適切でない状態になっていました。

## 改善点
- 表示用途ごとに最適なメッセージを生成可能に
- メッセージ変更時の影響範囲を限定
- Notificationモデルに責務を集約し、設計をシンプル化

## 確認方法
- パンの状態に応じてNotificationが作成されること
- LINE通知が想定通りの文面で送信されること
- お知らせ一覧でシンプルな文面が表示されること