### PR TITLE
LINE未連携のユーザーにLINE通知機能があることを表示

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,13 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  def create
+    super do |user|
+      if user.persisted? && user.line_user_id.blank?
+        Notification.create!(
+          user: user,
+          notification_type: "system",
+          message: "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。"
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,7 +5,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         Notification.create!(
           user: user,
           notification_type: "system",
-          message: "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。"
+          message: Notification.line_promo_message
         )
       end
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,6 +6,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
           user: user,
           notification_type: "system",
           message: Notification.line_promo_message
+          notified_at: Time.zone.now
         )
       end
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,7 +5,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         Notification.create!(
           user: user,
           notification_type: "system",
-          message: Notification.line_promo_message
+          message: Notification.line_promo_message,
           notified_at: Time.zone.now
         )
       end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,6 +14,7 @@ class Users::SessionsController < Devise::SessionsController
           user: resource,
           notification_type: "system",
           message: Notification.line_promo_message
+          notified_at: Time.zone.now
         )
       end
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,7 +13,7 @@ class Users::SessionsController < Devise::SessionsController
         Notification.create!(
           user: resource,
           notification_type: "system",
-          message: Notification.line_promo_message
+          message: Notification.line_promo_message,
           notified_at: Time.zone.now
         )
       end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,6 +8,14 @@ class Users::SessionsController < Devise::SessionsController
     
     super do |resource|
       resource.remember_me = true
+
+      if resource.persisted? && resource.line_user_id.blank? && !Notification.exists?(user: resource, notification_type: "system")
+        Notification.create!(
+          user: resource,
+          notification_type: "system",
+          message: Notification.line_promo_message
+        )
+      end
     end
   end
   # GET /users/sign_in

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,11 +19,11 @@ class UsersController < ApplicationController
           notification_type: "system",
           message: "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。",
         )
+      end
 
         redirect_to home_path
-      else
-        render :new
-      end
+    else
+      render :new
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,24 +9,6 @@ class UsersController < ApplicationController
     end
   end
 
-  def create
-    @user = User.new(user_params)
-    if @user.save
-      # LINE連携していないユーザーに通知を作成
-      if @user.line_user_id.blank?
-        Notification.create!(
-          user: @user,
-          notification_type: "system",
-          message: "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。",
-        )
-      end
-
-        redirect_to home_path
-    else
-      render :new
-    end
-  end
-
   private
 
   def user_params

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,6 @@
 class Notification < ApplicationRecord
   belongs_to :user
-  belongs_to :bread
+  belongs_to :bread, optional: true
 
   enum notification_type: {
     # 期限切れ当日通知

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,8 +8,6 @@ class Notification < ApplicationRecord
     # 明日在庫切れ通知
     run_out_tomorrow: "run_out_tomorrow",
     system: "system",
-    # お知らせ用
-    new_feature: "new_feature"
   }
 
   def display_message
@@ -32,6 +30,11 @@ class Notification < ApplicationRecord
     when "run_out_tomorrow"
       "#{greeting}\n\n #{display_message}\n補充をお忘れなく 🛒"
     end
+  end
+
+  # LINE通知機能追加のお知らせ
+  def self.line_promo_message
+    "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。"
   end
 
     private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -34,7 +34,7 @@ class Notification < ApplicationRecord
 
   # LINE通知機能追加のお知らせ
   def self.line_promo_message
-    "LINE通知機能が追加されました！\n設定一覧からLINE通知を受け取る設定ができます。"
+    "LINE通知機能が追加されました！<br>設定一覧からLINE通知を受け取る設定ができます。"
   end
 
     private

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -16,8 +16,8 @@
           <!-- システムお知らせ -->
           <div style="padding: 12px;">
             <p style="font-weight: bold;">【お知らせ】</p>
-            <p style="white-space: pre-line;">
-              <%= notification.display_message %>
+            <p>
+              <%= simple_format(notification.display_message) %>
             </p>
           </div>
           <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
  
   # 通常ログイン
-  devise_for :users, controllers: { sessions: 'users/sessions', omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { sessions: 'users/sessions', omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'users/registrations' }
 
   root "top#index"
   get "/home", to: "home#index"
@@ -66,8 +66,5 @@ Rails.application.routes.draw do
   get  "/invite/:token", to: "invitations#show", as: :invite
   post "/invite/:token/join", to: "invitations#join", as: :join_invite
 
-  devise_for :users, controllers: {
-    registrations: "users/registrations"
-  }
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
   get  "/invite/:token", to: "invitations#show", as: :invite
   post "/invite/:token/join", to: "invitations#join", as: :join_invite
 
-  
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
 
 end

--- a/db/migrate/20260427011907_change_bread_id_null_on_notifications.rb
+++ b/db/migrate/20260427011907_change_bread_id_null_on_notifications.rb
@@ -1,0 +1,5 @@
+class ChangeBreadIdNullOnNotifications < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :notifications, :bread_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_27_000241) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_27_011907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_27_000241) do
 
   create_table "notifications", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "bread_id", null: false
+    t.bigint "bread_id"
     t.string "notification_type", null: false
     t.string "message"
     t.boolean "is_read", default: false, null: false

--- a/spec/helpers/users/registrations_helper_spec.rb
+++ b/spec/helpers/users/registrations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Users::RegistrationsHelper. For example:
+#
+# describe Users::RegistrationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Users::RegistrationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
- ユーザー登録時にLINE未連携の場合お知らせにLINE通知機能の案内を表示するようにしたが、表示がされていなかった
- Notificationモデル設計の整合性が取れていなかった為修正した
- 構文エラーも発生していた為、修正した

## 変更内容
- 通知メッセージをモデルに集約（重複排除）
- ユーザー登録時（RegistrationsController）に通知作成
- ログイン時（SessionsController）にも通知作成（既存ユーザー対応）
  - 未連携かつ未作成の場合のみ作成（重複防止）
- bread_idをoptionalに変更し、システム通知に対応
- notified_atを自動設定するよう修正

## 確認方法
- LINE未連携のユーザーに通知一覧にお知らせとしてLINE通知機能について表示されているか

## 技術的ポイント
- DeviseのRegistrationsController / SessionsControllerをoverride
- 通知の責務をモデルに集約
- DB制約（NOT NULL）とモデルの整合性を調整

## 補足
Notification作成ロジックが分散しているためリファクタの余地あり
