### PR TITLE
アプリのLINEアカウントを友だち追加するボタンを追加

### DIFF
--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -21,8 +21,23 @@
           <p class="text-green-600 mb-4">
             LINE連携済みです
           </p>
+
+          <p class="text-sm text-gray-500 mb-2">
+            通知を受け取るには友だち追加が必要です<br>
+            まずはLINEで友だち追加をしてください
+          </p>
+          
+          <a href="https://lin.ee/rrzcxqV"
+             target="_blank"
+             rel="noopener"
+             class="inline-block mb-4">
+            <%= image_tag "https://scdn.line-apps.com/n/line_add_friends/btn/ja.png",
+                alt: "LINEで友だち追加",
+                class: "mx-auto w-40" %>
+          </a>
+
           <p class="text-sm text-gray-500 mb-4">
-            LINE通知のON/OFFを切り替えることができます
+            LINE通知はON/OFFを切り替えることができます
           </p>
 
           <%= form_with model: current_user, url: user_path(current_user), method: :patch do |f| %>
@@ -37,19 +52,29 @@
         <% else %>
           <!-- 👇 未連携 -->
 
-          <p class="text-gray-500 mb-4">
-            LINE通知を利用するには<br>
-            LINEアカウントと連携し、友達追加が必要です
-          </p>
+        <p class="text-gray-500 mb-2">
+          LINE通知を利用するには
+        </p>
 
-          <%= button_to "LINEと連携する",
+        <div class="mb-4">
+          <p class="text-gray-500 mb-2">
+            ①LINEで友だち追加
+          </p>
+          <a href="https://lin.ee/rrzcxqV"
+             target="_blank"
+             rel="noopener"
+             class="inline-block mb-4">
+            <%= image_tag "https://scdn.line-apps.com/n/line_add_friends/btn/ja.png",
+                alt: "LINEで友だち追加",
+                class: "mx-auto w-40" %>
+          </a>
+          <%= button_to "② LINEと連携する",
               user_line_omniauth_authorize_path,
               method: :post,
               data: { turbo: false },
-              class: "btn btn-success" %>
-
+              class: "btn btn-success w-full" %>
+        </div>
         <% end %>
-
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

LINE通知設定画面に友だち追加導線を追加し、通知が正常に届くようにUXを改善しました。

## 変更内容

* LINE友だち追加ボタンを追加
* 未連携時に「①友だち追加 → ②LINE連携」のステップを明示
* 連携済みユーザーにも友だち追加導線を表示
* 友だち追加ボタンのサイズを調整（w-40）

## 背景

LINE Messaging APIでは、ユーザーが友だち追加していない場合、Push通知を送信できません。
そのため、従来の「LINE連携のみ」の導線では通知が届かないケースが発生する可能性がありました。

## 変更前

* LINE連携のみで通知ONにできる
* 友だち追加導線がなく、通知が届かない可能性あり

## 変更後

* 友だち追加導線を追加
* 通知利用に必要なステップが明確化

## 確認方法

1. 通知設定画面を開く
2. 未連携時：

   * 友だち追加ボタンとLINE連携ボタンが表示されること
3. 連携済み時：

   * 友だち追加ボタンが表示されること
   * 通知ON/OFFが切り替えられること

## 今後の改善案
* Webhookで友だち追加状態を管理（follow/unfollowイベント）
* 友だち未追加時に通知ONを制御する
