### PR TITLE
お問合せページの設置

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+  def contact
+  end
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/sub_header", title: "通知設定", back_path: home_path %>
+<%= render "shared/sub_header", title: "LINE通知設定", back_path: settings_path %>
 
 <div class="min-h-screen bg-base-200 pt-8">
   <div class="mt-6 mb-4 max-w-lg mx-auto px-4">

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,32 @@
+<%= render "shared/sub_header", title: "お問合せ",back_path: settings_path %>
+
+<div class="bg-base-200 min-h-screen pt-10">
+  <div class="max-w-md mx-auto">
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body text-center">
+        <h2 class="card-title text-lg mb-4 justify-center">
+          📩 お問い合わせ
+        </h2>
+
+        <p class="text-gray-500 mb-6">
+          ご不明点やご要望がございましたら、<br>
+          下記フォームよりお気軽にお問い合わせください。
+        </p>
+
+        <div class="flex justify-center">
+          <a href="https://forms.gle/kHPubAXPUkcivBES8"
+            target="_blank"
+            rel="noopener"
+            class="btn btn-primary w-48 mt-2">
+            お問い合わせはこちら
+          </a>
+        </div>
+
+        <p class="text-xs text-gray-400 pt-6">
+          pankabi
+        </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -27,6 +27,11 @@
     <span class="text-base-content/40">›</span>
   <% end %>
 
+  <%= link_to contact_path, class: "flex items-center justify-between py-4" do %>
+    <span>お問合せ</span>
+    <span class="text-base-content/40">›</span>
+  <% end %>
+
 </div>
 
 <% if user_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'pages/contact'
   get 'notifications/index'
   get 'notification_settings/show'
   get 'notification_settings/edit'
@@ -66,5 +67,7 @@ Rails.application.routes.draw do
   get  "/invite/:token", to: "invitations#show", as: :invite
   post "/invite/:token/join", to: "invitations#join", as: :join_invite
 
+  # お問合せ
+  get 'contact', to: 'pages#contact'
 
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PagesHelper. For example:
+#
+# describe PagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /contact" do
+    it "returns http success" do
+      get "/pages/contact"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/pages/contact.html.tailwindcss_spec.rb
+++ b/spec/views/pages/contact.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "pages/contact.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やったこと
設定一覧からお問い合わせできるようにするため、Googleフォームへの導線を追加しました。
また、`/contact` ページを新規作成し、問い合わせ導線を一元化しました。


## 変更内容

* `PagesController` を作成し `contact` アクションを追加
* `/contact` ページを新規作成
* Googleフォームへのリンクボタンを設置
* 設定一覧に「お問い合わせ」リンクを追加
* UIを既存デザイン（cardレイアウト）に統一


## 背景・目的
ユーザーからの問い合わせ導線がなかったため追加。
まずは実装コストを抑えるため、Googleフォームを利用。


## 動作確認
* `/contact` にアクセスできること
* 「お問い合わせはこちら」ボタンでGoogleフォームが開くこと
* 設定一覧から遷移できること


## 補足
https://forms.gle/nH91S5226Lu3VEbn9

## 関連issue
close #96 
