### PR TITLE
fix: スマホ表示時のカルーセルUIを改善

### DIFF
--- a/app/views/home/_bread_card.html.erb
+++ b/app/views/home/_bread_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card w-full max-w-xs sm:max-w-sm h-[520px] sm:h-[580px] bg-base-100 shadow-md relative">
+<div class="card w-full max-w-xs sm:max-w-sm min-h-[80vh] sm:h-[580px] bg-base-100 shadow-md relative ">
   <div class="flex flex-col items-center justify-center text-center gap-4 p-5 sm:p-8 h-full">
     <div class="absolute top-4 right-6">
       <%= link_to edit_bread_path(bread),
@@ -26,19 +26,19 @@
     <p class="text-lg sm:text-2xl font-bold mt-2">
       <%= bread.status_message %>
     </p>
-    <span class="bg-yellow-100 p-4 mt-4 rounded-2xl inline-block w-60">
-      <p class="text-lg font-semibold">
+    <span class="bg-yellow-100 p-4 mt-6 rounded-2xl inline-block w-60">
+      <p class="text-lg font-semibold mt-2">
         消費期限
       </p>
     
-      <p class="text-2xl font-bold">
+      <p class="text-2xl font-bold mb-2 mt-2">
         <%= bread.expiration_date&.strftime("%Y年%m月%d日") %>
       </p>
     </span>
 
     <div class="flex items-center gap-3">
       <span class="bg-yellow-100 p-4 rounded-2xl inline-block w-60 text-center">
-        <p class="text-lg font-semibold">
+        <p class="text-lg font-semibold mt-2">
           のこり数
         </p>
         <%= render "home/bread_count", bread: bread %>
@@ -53,7 +53,7 @@
     <%= link_to line_share_url(bread),
               target: "_blank",
               rel: "noopener",
-              class: "flex items-center justify-center gap-2 text-green-600 hover:text-green-800 mt-4" do %>
+              class: "flex items-center justify-center gap-2 text-green-600 hover:text-green-800 mt-8" do %>
   
     <svg xmlns="http://www.w3.org/2000/svg"
          fill="none"

--- a/app/views/home/_no_bread_card.html.erb
+++ b/app/views/home/_no_bread_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card w-full max-w-xs sm:max-w-sm h-[520px] sm:h-[580px] bg-base-100 shadow-md relative">
+<div class="card w-full max-w-xs sm:max-w-sm min-h-[80vh] sm:h-[580px] bg-base-100 shadow-md relative">
   <div class="flex flex-col items-center justify-center text-center gap-4 p-5 sm:p-8 h-full">
     <p class="text-base font-semibold">
       パンがありません

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,21 +22,28 @@
         </div>
         
       </div>
-        
+      
+       <!-- 矢印（スマホ非表示） -->
       <button data-action="click->carousel#prev"
-              class="absolute left-5 top-1/2 -translate-y-1/2 btn btn-circle">
+              class="absolute left-5 top-1/2 -translate-y-1/2 btn btn-circle hidden sm:flex">
         ❮
       </button>
               
       <button data-action="click->carousel#next"
-              class="absolute right-5 top-1/2 -translate-y-1/2 btn btn-circle">
+              class="absolute right-5 top-1/2 -translate-y-1/2 btn btn-circle hidden sm:flex">
         ❯
       </button>
               
-          <!-- ドットエリア追加 -->
+          <!-- ドットエリア -->
       <div class="flex justify-center mt-4 space-x-2"
            data-carousel-target="dots">
       </div>
+
+      <!-- スワイプヒント（スマホのみ） -->
+      <div class="sm:hidden text-center text-xs text-gray-400 mt-2">
+        ← スワイプで確認できます →
+      </div>
+      
     </div>
   </div>
 </div>


### PR DESCRIPTION
## やったこと
スマホ表示時のカルーセルUIを改善しました。

## 変更点
- スマホ表示時にカルーセル矢印を非表示化
- スマホ向けに「← スワイプで確認できます →」
- ヒントを追加パンカードの高さを調整
- スマホ表示時の余白バランスを改善

## 影響範囲
ホーム画面の表示

## 動作確認方法
- スマホでカルーセルの高さがちょうど良くなっている
- パンを登録している時にカードが複数あることに気がつき自然に操作できるか確認

## やらないこと
カードの見切れ表示

## 補足
スマホ表示時にカードと矢印が重なって見栄えが悪くなっていたため、スワイプ操作前提のUIへ調整しました。
また、カード高さ不足による下部余白を改善し、視認性を向上しています。

## 関連issue
close #169 
