### PR TITLE
LINEログイン時のセッション保持

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 Rails.application.config.session_store :cookie_store,
   key: '_pankabi_session',
   secure: Rails.env.production?,
-  same_site: :lax
+  same_site: :lax,
+  expire_after: 30.days


### PR DESCRIPTION
## やったこと
LINEログイン時のセッション保持改善のため、`expire_after` を追加しました。

## 変更内容

* `session_store.rb` に `expire_after: 30.days` を追加
* ログイン状態を一定期間維持できるよう修正

## 確認項目

* LINEログイン後にページ遷移できること
* 再アクセス時にログイン状態が保持されること
* PC / スマホで問題なく動作すること

