### PR TITLE
fix:通知に必要なパンの情報の呼び出し方を修正

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -50,13 +50,6 @@ class Bread < ApplicationRecord
 
   after_commit :notify_if_needed, on: [:create, :update]
 
-
-  private
-
-  def set_remaining_count
-    self.remaining_count = total_count
-  end
-
   def notify_if_needed
     if expiration_date == Time.zone.today
       create_notification("expiration_today")
@@ -69,6 +62,12 @@ class Bread < ApplicationRecord
         create_notification("run_out_tomorrow")
       end
     end
+  end
+
+  private
+
+  def set_remaining_count
+    self.remaining_count = total_count
   end
 
   def create_notification(type)

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -3,9 +3,9 @@ namespace :notification do
   task create: :environment do
     Bread.joins(:user)
          .where(users: { line_notify_enabled: true })
-         .where("remaining_count > 0")
          .where("expiration_date >= ?", Time.zone.today)
          .find_each do |bread|
+      next unless bread.remaining_count > 0
       bread.notify_if_needed
     end
   end


### PR DESCRIPTION
## やったこと

LINE通知がCron Job実行時に届かない不具合を修正。

原因は2点：
1. `notification:create` タスクが `.where("remaining_count > 0")` でDBカラムをフィルタしていたが、`breads.remaining_count` カラムは実運用で書き込まれておらず常に `nil` のため、対象が0件となり `Notification` が作られていなかった（`Bread#remaining_count` はRubyメソッドで動的計算しているだけで、同名のDBカラムとは別物だった）。
2. `Bread#notify_if_needed` が `private` 配下にあり、Cronタスクから外部呼び出しすると `NoMethodError` になる状態だった。

## 変更点
- `lib/tasks/notification.rake` の `notification:create` から `.where("remaining_count > 0")` を削除し、ループ内で `next unless bread.remaining_count > 0` によりRubyメソッドで判定するように変更
- `app/models/bread.rb` の `notify_if_needed` を `private` の外に移動し、外部から呼び出し可能にした
- `set_remaining_count` / `create_notification` は内部利用のみのため `private` のまま据え置き

## 影響範囲

- Render Cron Job 経由の毎朝のLINE通知作成・送信処理（`notification:create` → `notification:send`）が正常動作するようになる
- パン登録・更新時に動く `after_commit :notify_if_needed` の呼び出しは挙動変わらず（コールバックは `private` でも呼べるため、可視性変更による副作用なし）
- 既存の `Notification` レコード、UI、他モデルには影響なし

## 動作確認方法
- 期限が今日のパン、または明日在庫切れになるパンを `line_notify_enabled: true` のユーザーで用意
- `bin/rails notification:create` を実行 → 該当 `Notification` レコードが作成されることを確認
- `bin/rails notification:send` を実行 → ユーザーのLINEにメッセージが届くことを確認
- LINE未連携（`line_user_id` が空）・`line_notify_enabled: false` のユーザーには送信されないことを確認
- 本番マージ後、Render側で手動実行して通知到達を確認

## やらないこと
- `breads.remaining_count` カラム自体の整理（DBカラムとRubyメソッドが同名で別物になっている設計）は本PRでは触らない


## 補足
- `remaining_count` のカラム / メソッド同名問題は別途タスクとして整理したい（カラム廃止 or メソッドリネーム）
- マージ後、Render上で手動実行 → LINE着信確認 を予定
- 

