### PR TITLE
Test/fix factories

### DIFF
--- a/app/models/bread.rb
+++ b/app/models/bread.rb
@@ -2,6 +2,7 @@ class Bread < ApplicationRecord
   has_many :notifications, dependent: :destroy
   belongs_to :user, optional: true
   belongs_to :bread_type
+  belongs_to :group
   validates :expiration_date, presence: true
   validates :total_count, presence: true
   validates :daily_consumption, presence: true,

--- a/spec/factories/breads.rb
+++ b/spec/factories/breads.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :bread do
+    user
+    bread_type
+    group { user.groups.first }
+    total_count { 6 }
+    daily_consumption { 1 }
+    expiration_date { Time.zone.today + 4.days }
+  end
+end

--- a/spec/factories/default_breads.rb
+++ b/spec/factories/default_breads.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :default_bread do
-    user { nil }
-    bread_type { nil }
+    user
+    bread_type
     total_count { 1 }
-    daily_consumption { 1.5 }
+    daily_consumption { 1 }
   end
 end

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :invitation do
-    group { nil }
-    token { "MyString" }
-    expires_at { "2026-04-06 22:15:07" }
+    group
+    token { SecureRandom.urlsafe_base64 }
+    expires_at { 3.days.from_now }
+
+    trait :expired do
+      expires_at { 1.day.ago }
+    end
   end
 end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :membership do
-    user { nil }
-    group { nil }
+    user
+    group
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,10 +1,18 @@
 FactoryBot.define do
   factory :notification do
-    user { nil }
-    bread { nil }
-    notification_type { "MyString" }
-    message { "MyString" }
-    is_read { false }
-    notified_at { "2026-03-19 13:51:06" }
+    user
+    bread
+    notification_type { "expiration_today" }
+    notified_at { Time.current }
+
+    trait :run_out_tomorrow do
+      notification_type { "run_out_tomorrow" }
+    end
+
+    trait :system do
+      bread { nil }
+      notification_type { "system" }
+      message { "システムからのお知らせです" }
+    end
   end
 end


### PR DESCRIPTION
## 概要
spec/factories/ 配下のfactoryを実用可能な状態に整える。

## 変更内容
### モデル
- `Bread` モデルに `belongs_to :group` を追加
  - DBスキーマでは `breads.group_id NOT NULL` だが、モデル側に宣言が抜けていた不整合を解消
  - 既存のBread作成はすべて `current_group.breads.build` 経由のため、後方互換性に影響なし

### Factory
- `spec/factories/breads.rb` を新規作成（user / bread_type / group / 必須属性）
- `spec/factories/memberships.rb`：user / group の関連を実態に
- `spec/factories/default_breads.rb`：user / bread_type の関連を実態に、daily_consumption を整数に
- `spec/factories/invitations.rb`：group + `SecureRandom.urlsafe_base64` トークン + `3.days.from_now`
- `spec/factories/notifications.rb`：enum値 + user / bread の関連 + `Time.current`

## 検証
- [x] `bundle exec rspec` → 65 examples, 0 failures, 34 pending
- [x] 各factoryで `FactoryBot.create(:xxx)` がコンソールで成功することを確認
- [x] `belongs_to :group` 追加による既存コードへの影響なしをgrepで確認

## このPRに含めないもの
- Modelテストの実装
- Requestテストの拡充（
- 既存テストへの新factoryの適用（必要箇所のみ後続PRで）

