### PR TITLE
CIエラー対応　npm ciの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           node-version: 20
 
+      # 追加
+      - name: Install Node dependencies
+        run: npm ci
+
       # ④ DB準備
       - run: bin/rails db:prepare
 


### PR DESCRIPTION
## 概要
CI環境で `assets:precompile` が `Cannot find module 'daisyui'` で失敗していたのを修正。

## 背景
- 先のcleanup PR（`chore/cleanup-tracked-files`）で `node_modules/` をGitの追跡対象から外した
- これにより、CIサーバーがcheckoutしただけでは `node_modules` が存在しない状態に
- 一方でTailwindのbuild処理（`config/tailwind.config.js`）が `daisyui` を `require` しているため、`assets:precompile` でエラー

## 変更内容
- `.github/workflows/ci.yml` に `npm ci` ステップを追加
- `actions/setup-node@v4` 直後に挿入し、`assets:precompile` の前で完了するように配置

## 検証
- CI上で `Build CSS` ステップが成功するまで確認