### PR TITLE
Test/simple model specs

### DIFF
--- a/spec/models/bread_type_spec.rb
+++ b/spec/models/bread_type_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe BreadType, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーショnン' do
+    context 'nameが空の時' do
+      it '無効であること' do
+        bread_type = BreadType.new(name: nil)
+        expect(bread_type).to be_invalid
+      end
+    end
+    context 'nameが入っている時' do
+      it '有効であること' do
+        bread_type = BreadType.new(name: '食パン')
+        expect(bread_type).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/default_bread_spec.rb
+++ b/spec/models/default_bread_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe DefaultBread, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '関連' do
+    context 'userがnilの時' do
+      it '無効であること' do
+        default_bread = build(:default_bread, user: nil)
+        expect(default_bread).to be_invalid
+      end
+    end
+
+    context 'bread_typeがnilの時' do
+      it '無効であること' do
+        default_bread = build(:default_bread, bread_type: nil)
+        expect(default_bread).to be_invalid
+      end
+    end
+
+    context 'userとbread_typeが両方ある時' do
+      it '有効であること' do
+        default_bread = build(:default_bread)
+        expect(default_bread).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Invitation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '関連' do
+    context 'group がnilの時' do
+      it '無効であること' do
+        invitation = build(:invitation, group: nil)
+        expect(invitation).to be_invalid
+      end
+    end
+
+    context 'groupがある時' do
+      it '有効であること' do
+        invitation = build(:invitation)
+        expect(invitation).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Membership, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '関連' do
+    context 'userがnilの時' do
+      it '無効であること' do
+        membership = build(:membership, user: nil)
+        expect(membership).to be_invalid
+      end
+    end
+
+    context 'groupがnilの時' do
+      it '無効であること' do
+        membership = build(:membership, group: nil)
+        expect(membership).to be_invalid
+      end
+    end
+
+    context 'userとgroupが両方ある時' do
+      it '有効であること' do
+        membership = build(:membership)
+        expect(membership).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
比較的シンプルな4つのモデル（BreadType / Membership / Invitation / DefaultBread）のmodel specを実装。Issue #YY（テスト実装）のサブissueに対応。

## 変更内容
- `spec/models/bread_type_spec.rb`：name の presence バリデーション
- `spec/models/membership_spec.rb`：user / group の belongs_to 必須確認
- `spec/models/invitation_spec.rb`：group の belongs_to 必須確認
- `spec/models/default_bread_spec.rb`：user / bread_type の belongs_to 必須確認

## 検証
- [x] `bundle exec rspec` → 71 examples, 0 failures, 30 pending
- [x] 元の 34 pending から 4 件解消（4ファイル分のスケルトン置き換え）

## このPRに含めないもの
- Notification / Bread / User の model spec → 別サブissueで対応
- Request / System spec → 別サブissueで対応

Closes #181 
