### PR TITLE
test:add notification_spec

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,7 +15,7 @@ class Notification < ApplicationRecord
     when "expiration_today"
       "パンの消費期限が今日までです"
     when "run_out_tomorrow"
-      "明日在庫がなくなります"
+      "パンの在庫が明日なくなります"
     when "system"
       message
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -36,4 +36,62 @@ RSpec.describe Notification, type: :model do
       }.to raise_error(ArgumentError)
     end
   end
+
+  describe '#display_message' do
+    context 'expiration_today のとき' do
+      it '期限切れメッセージを返す' do
+        notification = build(:notification, notification_type: 'expiration_today')
+        expect(notification.display_message).to eq('パンの消費期限が今日までです')
+      end
+    end
+
+    context 'run_out_tomorrow のとき' do
+      it '在庫切れメッセージを返す' do
+        notification = build(:notification, notification_type: 'run_out_tomorrow')
+        expect(notification.display_message).to eq('パンの在庫が明日なくなります')
+      end
+    end
+
+    context 'system のとき' do
+      it 'message属性をそのまま返す' do
+        notification = build(
+          :notification,
+          notification_type: 'system',
+          bread: nil,
+          message: 'システムからのお知らせです'
+        )
+        expect(notification.display_message).to eq('システムからのお知らせです')
+      end
+    end
+  end
+
+  describe '#line_message' do
+    context 'expiration_today のとき' do
+      it '挨拶と display_message が含まれる' do
+        notification = build(:notification, notification_type: 'expiration_today')
+        expect(notification.line_message).to include('おはようございます')
+        expect(notification.line_message).to include(notification.display_message)
+      end
+    end
+
+    context 'run_out_tomorrow のとき' do
+      it '挨拶と display_message が含まれる' do
+        notification = build(:notification, notification_type: 'run_out_tomorrow')
+        expect(notification.line_message).to include('おはようございます')
+        expect(notification.line_message).to include(notification.display_message)
+      end
+    end
+
+    context 'system のとき' do
+      it 'nil を返す' do
+        notification = build(
+          :notification,
+          notification_type: 'system',
+          bread: nil,
+          message: 'システム通知'
+        )
+        expect(notification.line_message).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Notification, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '関連' do
+    context 'userがnilの時' do
+      it '無効であること' do
+        notification = build(:notification, user: nil)
+        expect(notification).to be_invalid
+      end
+    end
+
+    context 'userがある時' do
+      it '有効であること' do
+        notification = build(:notification)
+        expect(notification).to be_valid
+      end
+    end
+
+    context 'user / bread 両方ある時' do
+      it '有効であること' do
+        notification = build(:notification)
+        expect(notification).to be_valid
+      end
+    end
+  end
+
+  describe 'enum notification_type' do
+    it '3つの値が定義されていること' do
+      expect(Notification.notification_types.keys).to contain_exactly(
+        'expiration_today', 'run_out_tomorrow', 'system')
+    end
+
+    it '無効な値を設定するとエラーになる' do
+      expect {
+        build(:notification, notification_type: 'invalid')
+      }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
Notificationモデルのmodel specを実装。Issue #182（Step C-2）に対応。

## 変更内容
- `spec/models/notification_spec.rb`：
  - 関連（user 必須 / bread optional）
  - enum notification_type（定義済み3値の確認、無効値のエラー）
  - `#display_message`（type ごとの戻り値）
  - `#line_message`（挨拶と display_message の含有確認、system は nil）
- `app/models/notification.rb` の `display_message` の文言を「明日在庫がなくなります」→「パンの在庫が明日なくなります」に修正
  - より自然な日本語に整えた

## 検証
- [x] `bundle exec rspec` → 81 examples, 0 failures, 29 pending

## 関連issue
Closes #182
