### PR TITLE
test(request): add Users::Registrations spec

### DIFF
--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,7 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe "Users::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe 'POST /users（新規登録）' do
+    context '有効なパラメータのとき' do
+      let(:valid_params) do
+        {
+          user: {
+            email: 'newuser@example.com',
+            password: 'password123',
+            password_confirmation: 'password123'
+          }
+        }
+      end
+
+      it 'Userが作成される' do
+        expect {
+          post user_registration_path, params: valid_params
+        }.to change(User, :count).by(1)
+      end
+
+      it 'システム通知（LINE案内）が作成される' do
+        expect {
+          post user_registration_path, params: valid_params
+        }.to change(Notification, :count).by(1)
+      end
+
+      it 'ホーム画面にリダイレクトされる' do
+        post user_registration_path, params: valid_params
+        expect(response).to redirect_to(home_path)
+      end
+    end
+
+    context '無効なパラメータのとき' do
+      let(:invalid_params) do
+        {
+          user: {
+            email: '',                            # ← email を空に
+            password: 'password123',
+            password_confirmation: 'password123'
+          }
+        }
+      end
+
+      it 'Userは作成されない' do
+        expect {
+          post user_registration_path, params: invalid_params
+        }.not_to change(User, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
ユーザー登録 / LINEログインのRequestspecを実装。Issue #186 （Step D-2）に対応。

## 変更内容
- `spec/requests/users/registrations_spec.rb`：
  - 有効パラメータでのUser作成・通知作成・リダイレクト
  - 無効パラメータでの非作成
- `spec/requests/users/omniauth_callbacks_spec.rb`：
  - LINE経由の新規ユーザー作成
  - LINE経由の既存ユーザーログイン（新規作成されない）
  - OmniAuth.config.test_mode によるモック仕込みを採用

## 補足
`auth.blank?` の防御コードのテストは、OmniAuth test mode では完全再現が難しいため今回はスコープ外。手動テスト or 別アプローチでカバー予定。

## 検証
- [x] `bundle exec rspec` → 全グリーン
130 examples, 0 failures, 26 pending

Closes #186
