### PR TITLE
test(system): add user registration flow spec

### DIFF
--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,7 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe "Users::OmniauthCallbacks", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe 'GET /users/auth/line/callback' do
+    before do
+      # OmniAuth をテストモードに
+      OmniAuth.config.test_mode = true
+      # Devise が認識できるようにマッピング設定
+      Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
+    end
+
+    after do
+      OmniAuth.config.mock_auth[:line] = nil
+      Rails.application.env_config["omniauth.auth"] = nil
+    end
+
+    context 'LINE認証が成功し、新規ユーザーのとき' do
+      before do
+        mock_auth = OmniAuth::AuthHash.new(
+          provider: 'line',
+          uid: 'line_user_12345',
+          info: { name: 'テストユーザー', email: 'test@example.com' }
+        )
+        OmniAuth.config.mock_auth[:line] = mock_auth
+        Rails.application.env_config["omniauth.auth"] = mock_auth
+      end
+
+      it '新規ユーザーが作成される' do
+        expect {
+          get user_line_omniauth_callback_path
+        }.to change(User, :count).by(1)
+      end
+    end
+
+    context 'LINE認証が成功し、既存ユーザーのとき' do
+      let!(:existing_user) do
+        create(:user, line_user_id: 'line_user_12345')
+      end
+
+      before do
+        mock_auth = OmniAuth::AuthHash.new(
+          provider: 'line',
+          uid: 'line_user_12345',
+          info: { name: 'テスト', email: 'test@example.com' }
+        )
+        OmniAuth.config.mock_auth[:line] = mock_auth
+        Rails.application.env_config["omniauth.auth"] = mock_auth
+      end
+
+      it '新規ユーザーは作られない（既存ユーザーでログインする）' do
+        expect {
+          get user_line_omniauth_callback_path
+        }.not_to change(User, :count)
+      end
+    end
   end
 end

--- a/spec/system/registration_flow_spec.rb
+++ b/spec/system/registration_flow_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe '新規登録フロー', type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  it 'ユーザーが新規登録するとホーム画面に到達できる' do
+    visit new_user_registration_path
+
+    fill_in 'メールアドレス', with: 'newuser@example.com'
+    fill_in 'パスワード', with: 'password123'
+    fill_in 'パスワード確認', with: 'password123'
+    click_button '登録する'
+
+    expect(page).to have_current_path(home_path)
+  end
+end


### PR DESCRIPTION
## 概要
新規登録フローの System spec を1本実装。Issue #187（Step E）に対応。

## 変更内容
- `spec/system/registration_flow_spec.rb` を新規作成
- サインアップ画面で必要項目を入力し、登録ボタン押下後にホーム画面に遷移することを確認
- driver は `:rack_test`（このフォームは turbo: false で JS 不要のため）

## このPRに含めないもの
- パン登録までの通しシナリオ（細部は Model/Request spec でカバー済み）
- JS必須の System spec（必要になったら別途）

Closes #187