### PR TITLE
fix: N+1問題を解消（includes追加）

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@ class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @breads = current_group.breads
+    @breads = current_group.breads.includes(:bread_type)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,6 +6,6 @@ class NotificationsController < ApplicationController
     current_user.notifications.where(is_read: false).update_all(is_read: true)
     
     # その後に取得
-    @notifications = current_user.notifications.order(created_at: :desc)
+    @notifications = current_user.notifications.includes(:bread).order(created_at: :desc)
   end
 end


### PR DESCRIPTION
## やったこと

ホーム画面と通知一覧でN+1問題が発生していたため、includesを追加して解消した。

## 変更点
- `HomeController#index` に `.includes(:bread_type)` を追加
- `NotificationsController#index` に `.includes(:bread)` を追加

## 影響範囲

データベースへのクエリ回数が削減される。画面の表示内容や動作には変更なし。

## 動作確認方法

- ホーム画面でパンのカードが正常に表示されること
- 通知一覧が正常に表示されること

## やらないこと

パフォーマンス計測（今後必要であれば Bullet gem の導入を検討）

## 補足

パンが増えるほどクエリ数が増える問題だったため、早めに対応。