### PR TITLE
招待URL経由でLINEログインした場合、ログイン後にグループへ自動参加させる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
-    home_path
+    stored_location_for(resource) || home_path
   end
 
   def after_sign_up_path_for(resource)

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,10 +16,23 @@
     <%= f.submit "ログイン", class: "btn btn-primary w-40 mx-auto block text-lg" %>
   </div>
 
+
+
   <p class="text-center text-sm text-gray-500 mt-4">
     <%= link_to "パスワードを忘れた場合", new_user_password_path,
         class: "link link-primary" %>
   </p>
-
 <% end %>
 
+<div class="text-center text-sm text-gray-400 my-4">または</div>
+
+<div class="flex justify-center">
+  <%= button_to user_line_omniauth_authorize_path,
+    method: :post,
+    data: { turbo: false },
+    class: "btn btn-success btn-lg rounded-xl inline-flex w-40 px-6 transition-transform active:scale-95 text-center" do %>
+    <span class="flex items-center gap-2">
+      <span>LINE<br>ログイン</span>
+    </span>
+  <% end %>
+</div>


### PR DESCRIPTION
## やったこと
招待URLを踏んだ未ログインユーザーがLINEログインできない問題と、ログイン後にグループへ自動参加されない問題を修正。

## 変更点
- devise/sessions/new.html.erb にLINEログインボタンを追加
- application_controller.rb の after_sign_in_path_for を stored_location_for を使う形に変更


## 影響範囲
ログイン画面
グループ参加後のホーム画面

## 動作確認方法
- 招待URLを踏んだ未ログインユーザーにLINEログインボタンが表示される
- LINEログイン後、自動的にグループに参加できる


## 補足
当初は session[:invite_token] にトークンを保存する方針で実装したが、LINE OAuth認証中にセッションがリセットされてしまい機能しなかった。DeviseにはAuthenticate_user!が弾いた時のURLを自動で保存する stored_location_for という仕組みがあるため、これを利用することで解決した。

## 関連issue
close #199 
