### PR TITLE
fix: OCRエンドポイントを認証済みユーザーのみに制限する

### DIFF
--- a/app/controllers/ocrs_controller.rb
+++ b/app/controllers/ocrs_controller.rb
@@ -1,6 +1,6 @@
 class OcrsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:create]
-
+  before_action :authenticate_user!
+  before_action :reject_guest_user
 
   def create
     image = params[:image]

--- a/app/views/breads/_form.html.erb
+++ b/app/views/breads/_form.html.erb
@@ -13,7 +13,8 @@
     class: "input input-bordered mb-2" %>
 
     <p data-ocr-target="status" class="text-sm text-gray-500 mt-1"></p>
-  
+
+    <% if user_signed_in? && !current_user.guest? %>
     <!-- 区切り -->
     <div class="text-center text-sm text-gray-400 my-2">または</div>
 
@@ -26,6 +27,7 @@
              accept="image/*"
              class="hidden">
     </label>
+    <% end %>
   </div>
 
 


### PR DESCRIPTION
## やったこと

Google Cloud Vision APIの不正利用・意図しない課金を防ぐため、OCR機能を認証済みの通常ユーザーのみに制限する

## 変更点
- ocrs_controller.rb に before_action :authenticate_user! と before_action :reject_guest_user を追加
- skip_before_action :verify_authenticity_token を削除（不要なため）
- breads/_form.html.erb のOCRボタンをゲスト・未ログインユーザーには非表示にする

## 影響範囲
-ゲストログイン時のパンの登録画面

## 動作確認方法
- ゲストユーザーでOCRボタンが表示されない
- 通常ユーザーでOCRボタンが表示され、OCR機能が使える

## 関連issue
close #200 
