### PR TITLE
fix:消費期限が切れていた場合在庫がなくなる通知が来なくなるのを修正

### DIFF
--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -4,9 +4,7 @@ namespace :notification do
   task create: :environment do
     Bread.joins(:user)
          .where(users: { line_notify_enabled: true })
-         .where("expiration_date >= ?", Time.zone.today)
          .find_each do |bread|
-      next unless bread.remaining_count > 0
       bread.notify_if_needed
     end
   end


### PR DESCRIPTION
## 概要
消費期限が切れたパンについて、在庫が残っていても「在庫が明日なくなります」通知が作成されなくなる不具合を修正。

## 原因
`notification:create` タスクが以下の条件で対象を絞り込んでいた。

- `where("expiration_date >= ?", Time.zone.today)` … 消費期限切れのパンをクエリ対象から除外
- `next unless bread.remaining_count > 0` … 在庫0のパンをスキップ

`Bread#notify_if_needed` は期限判定(expiration_today)と在庫判定(run_out_tomorrow)が独立したロジックだが、上記2条件により消費期限切れ後は`notify_if_needed`自体が呼ばれなくなり、在庫が残っていても通知が作成されなくなっていた。

## 修正内容
- `where("expiration_date >= ?", ...)` を削除（期限判定は notify_if_needed 内部に任せる）
- `next unless bread.remaining_count > 0` を削除（在庫判定は run_out_tomorrow 側の条件で担保済み）

## 確認事項
- [ ] 期限切れ後も在庫がある限り run_out_tomorrow が正しいタイミングで発火する
- [ ] 在庫が0になった時点で自然に通知が止まる


## 関連issue
close #207 
